### PR TITLE
Add analysis tracking system with database storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ The internal package has been restructured into focused subpackages for better o
 Contains configuration management, Git client interfaces, time utilities, and general-purpose helpers.
 
 ### iocache/
-Implements I/O caching functionality with support for multiple database backends (SQLite, MySQL, PostgreSQL).
+Implements I/O caching and analysis tracking functionality with support for multiple database backends (SQLite, MySQL, PostgreSQL).
 
 ### outwriter/
 Handles output formatting and writing for different formats (text tables, JSON, CSV) and analysis types (files, folders, comparisons, timeseries).

--- a/core/agg/agg_caching_test.go
+++ b/core/agg/agg_caching_test.go
@@ -31,6 +31,15 @@ func (m *MockCacheManager) GetActivityStore() contract.CacheStore {
 	return val.(contract.CacheStore)
 }
 
+func (m *MockCacheManager) GetAnalysisStore() contract.AnalysisStore {
+	ret := m.Called()
+	val := ret.Get(0)
+	if val == nil {
+		return nil
+	}
+	return val.(contract.AnalysisStore)
+}
+
 func TestCheckCacheHit_CacheHit(t *testing.T) {
 	mockStore := &MockCacheStore{}
 	result := &schema.AggregateOutput{

--- a/core/analysis.go
+++ b/core/analysis.go
@@ -250,8 +250,6 @@ func analyzeFileCommon(ctx context.Context, cfg *contract.Config, client contrac
 	// 4. Record metrics and scores to database (if analysis tracking is enabled)
 	if analysisID, ok := getAnalysisID(ctx); ok && analysisID > 0 {
 		// Get the analysis store from the context via the cache manager
-		// Note: We need to pass the cache manager through the context or another mechanism
-		// For now, we'll use a global reference (to be improved)
 		recordFileAnalysis(ctx, cfg, analysisID, path, &result)
 	}
 

--- a/core/analysis.go
+++ b/core/analysis.go
@@ -27,6 +27,31 @@ func runSingleAnalysisCore(ctx context.Context, cfg *contract.Config, client con
 		internal.LogAnalysisHeader(cfg)
 	}
 
+	// Add cache manager to context for use in worker goroutines
+	ctx = contextWithCacheManager(ctx, mgr)
+
+	// --- 0. Begin Analysis Tracking (if configured) ---
+	var analysisID int64
+	analysisStore := mgr.GetAnalysisStore()
+	if analysisStore != nil {
+		startTime := time.Now()
+		configParams := map[string]any{
+			"mode":         string(cfg.Mode),
+			"lookback":     cfg.Lookback.String(),
+			"repo_path":    cfg.RepoPath,
+			"workers":      cfg.Workers,
+			"result_limit": cfg.ResultLimit,
+		}
+		var err error
+		analysisID, err = analysisStore.BeginAnalysis(startTime, configParams)
+		if err != nil {
+			contract.LogWarn("Analysis tracking initialization failed", err)
+		} else if analysisID > 0 {
+			// Add analysis ID to context for use in file analysis
+			ctx = withAnalysisID(ctx, analysisID)
+		}
+	}
+
 	// --- 1. Aggregation Phase (with caching) ---
 	output, err := agg.CachedAggregateActivity(ctx, cfg, client, mgr)
 	if err != nil {
@@ -41,6 +66,14 @@ func runSingleAnalysisCore(ctx context.Context, cfg *contract.Config, client con
 
 	// --- 3. Core Analysis ---
 	fileResults := analyzeRepo(ctx, cfg, client, output, files)
+
+	// --- 4. End Analysis Tracking ---
+	if analysisStore != nil && analysisID > 0 {
+		endTime := time.Now()
+		if err := analysisStore.EndAnalysis(analysisID, endTime, len(fileResults)); err != nil {
+			contract.LogWarn("Failed to finalize analysis tracking", err)
+		}
+	}
 
 	return &schema.SingleAnalysisOutput{
 		FileResults:     fileResults,
@@ -211,8 +244,90 @@ func analyzeFileCommon(ctx context.Context, cfg *contract.Config, client contrac
 		CalculateOwner().          // Calculates file owner
 		CalculateScore()           // Computes the final composite score
 
-	// 3. Return the final product
-	return builder.Build()
+	// 3. Build the final result
+	result := builder.Build()
+
+	// 4. Record metrics and scores to database (if analysis tracking is enabled)
+	if analysisID, ok := getAnalysisID(ctx); ok && analysisID > 0 {
+		// Get the analysis store from the context via the cache manager
+		// Note: We need to pass the cache manager through the context or another mechanism
+		// For now, we'll use a global reference (to be improved)
+		recordFileAnalysis(ctx, cfg, analysisID, path, &result)
+	}
+
+	return result
+}
+
+// recordFileAnalysis records file metrics and scores to the database.
+func recordFileAnalysis(ctx context.Context, cfg *contract.Config, analysisID int64, path string, result *schema.FileResult) {
+	// Get the cache manager from context
+	mgr := cacheManagerFromContext(ctx)
+	if mgr == nil {
+		return
+	}
+
+	analysisStore := mgr.GetAnalysisStore()
+	if analysisStore == nil {
+		return
+	}
+
+	now := time.Now()
+
+	// Record raw git metrics
+	metrics := schema.FileMetrics{
+		AnalysisTime:     now,
+		TotalCommits:     result.Commits,
+		TotalChurn:       result.Churn,
+		ContributorCount: result.UniqueContributors,
+		AgeDays:          float64(result.AgeDays), // Convert int to float64 for type compatibility with FileMetrics struct
+		GiniCoefficient:  result.Gini,
+		FileOwner:        getOwnerString(result.Owners),
+	}
+	if err := analysisStore.RecordFileMetrics(analysisID, path, metrics); err != nil {
+		logTrackingError("RecordFileMetrics", path, err)
+	}
+
+	// Compute all four scoring modes
+	allScores := computeAllScores(result, cfg.CustomWeights)
+
+	// Record final scores
+	scores := schema.FileScores{
+		AnalysisTime:    now,
+		HotScore:        allScores[schema.HotMode],
+		RiskScore:       allScores[schema.RiskMode],
+		ComplexityScore: allScores[schema.ComplexityMode],
+		StaleScore:      allScores[schema.StaleMode],
+		ScoreLabel:      string(cfg.Mode),
+	}
+	if err := analysisStore.RecordFileScores(analysisID, path, scores); err != nil {
+		logTrackingError("RecordFileScores", path, err)
+	}
+}
+
+// computeAllScores computes scores for all four modes.
+func computeAllScores(m *schema.FileResult, customWeights map[schema.ScoringMode]map[schema.BreakdownKey]float64) map[schema.ScoringMode]float64 {
+	scores := make(map[schema.ScoringMode]float64)
+
+	// Compute score for each mode without mutating the input
+	for _, mode := range []schema.ScoringMode{schema.HotMode, schema.RiskMode, schema.ComplexityMode, schema.StaleMode} {
+		mCopy := *m
+		mCopy.Mode = mode
+		scores[mode] = computeScore(&mCopy, mode, customWeights)
+	}
+	return scores
+}
+
+// getOwnerString converts the owners slice to a string.
+func getOwnerString(owners []string) string {
+	if len(owners) == 0 {
+		return ""
+	}
+	return owners[0] // Return the primary owner
+}
+
+// logTrackingError logs database tracking errors to stderr without disrupting analysis.
+func logTrackingError(operation, path string, err error) {
+	contract.LogWarn(fmt.Sprintf("Analysis tracking failed for %s on %s", operation, path), err)
 }
 
 // getAnalysisWindowForRef queries Git for the exact commit time of the given reference

--- a/core/analysis_orchestration_test.go
+++ b/core/analysis_orchestration_test.go
@@ -19,8 +19,9 @@ func TestRunSingleAnalysisCore_Success(t *testing.T) {
 
 	// Setup mock expectations
 	mockMgr.On("GetActivityStore").Return(nil) // No caching for test
-	mockClient.On("ListFilesAtRef", ctx, "/test/repo", "HEAD").Return([]string{"main.go", "core/agg.go"}, nil)
-	mockClient.On("GetActivityLog", ctx, "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).Return([]byte("--abc123|Alice|2024-01-01T00:00:00Z\n1\t0\tmain.go\n"), nil)
+	mockMgr.On("GetAnalysisStore").Return(nil) // No analysis tracking for test
+	mockClient.On("ListFilesAtRef", mock.AnythingOfType("*context.valueCtx"), "/test/repo", "HEAD").Return([]string{"main.go", "core/agg.go"}, nil)
+	mockClient.On("GetActivityLog", mock.AnythingOfType("*context.valueCtx"), "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).Return([]byte("--abc123|Alice|2024-01-01T00:00:00Z\n1\t0\tmain.go\n"), nil)
 
 	cfg := &contract.Config{
 		RepoPath:    "/test/repo",
@@ -50,8 +51,9 @@ func TestRunSingleAnalysisCore_NoFilesFound(t *testing.T) {
 
 	// Setup mock expectations - return empty file list
 	mockMgr.On("GetActivityStore").Return(nil) // No caching for test
-	mockClient.On("ListFilesAtRef", ctx, "/test/repo", "HEAD").Return([]string{}, nil)
-	mockClient.On("GetActivityLog", ctx, "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).Return([]byte(""), nil)
+	mockMgr.On("GetAnalysisStore").Return(nil) // No analysis tracking for test
+	mockClient.On("ListFilesAtRef", mock.AnythingOfType("*context.valueCtx"), "/test/repo", "HEAD").Return([]string{}, nil)
+	mockClient.On("GetActivityLog", mock.AnythingOfType("*context.valueCtx"), "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).Return([]byte(""), nil)
 
 	cfg := &contract.Config{
 		RepoPath:  "/test/repo",
@@ -78,8 +80,9 @@ func TestRunSingleAnalysisCore_AggregationError(t *testing.T) {
 
 	// Setup mock expectations - aggregation fails
 	mockMgr.On("GetActivityStore").Return(nil) // No caching for test
-	mockClient.On("ListFilesAtRef", ctx, "/test/repo", "HEAD").Return([]string{"main.go"}, nil)
-	mockClient.On("GetActivityLog", ctx, "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).Return(nil, assert.AnError)
+	mockMgr.On("GetAnalysisStore").Return(nil) // No analysis tracking for test
+	mockClient.On("ListFilesAtRef", mock.AnythingOfType("*context.valueCtx"), "/test/repo", "HEAD").Return([]string{"main.go"}, nil)
+	mockClient.On("GetActivityLog", mock.AnythingOfType("*context.valueCtx"), "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).Return(nil, assert.AnError)
 
 	cfg := &contract.Config{
 		RepoPath:  "/test/repo",

--- a/core/context.go
+++ b/core/context.go
@@ -1,6 +1,10 @@
 package core
 
-import "context"
+import (
+	"context"
+
+	"github.com/huangsam/hotspot/internal/contract"
+)
 
 // Context keys for analysis options.
 type contextKey string
@@ -8,6 +12,7 @@ type contextKey string
 const (
 	suppressHeaderKey contextKey = "suppressHeader"
 	useFollowKey      contextKey = "useFollow"
+	analysisIDKey     contextKey = "analysisID"
 )
 
 // withSuppressHeader sets whether headers should be suppressed in the context.
@@ -38,4 +43,36 @@ func shouldUseFollow(ctx context.Context) bool {
 	}
 	useFollow, ok := val.(bool)
 	return ok && useFollow
+}
+
+// withAnalysisID sets the analysis ID in the context.
+func withAnalysisID(ctx context.Context, analysisID int64) context.Context {
+	return context.WithValue(ctx, analysisIDKey, analysisID)
+}
+
+// getAnalysisID returns the analysis ID from context.
+func getAnalysisID(ctx context.Context) (int64, bool) {
+	val := ctx.Value(analysisIDKey)
+	if val == nil {
+		return 0, false
+	}
+	id, ok := val.(int64)
+	return id, ok
+}
+
+// cacheManagerKey is the context key for the cache manager.
+type cacheManagerKeyType struct{}
+
+// contextWithCacheManager returns a new context with the given CacheManager.
+func contextWithCacheManager(ctx context.Context, mgr contract.CacheManager) context.Context {
+	return context.WithValue(ctx, cacheManagerKeyType{}, mgr)
+}
+
+// cacheManagerFromContext retrieves the CacheManager from the context.
+func cacheManagerFromContext(ctx context.Context) contract.CacheManager {
+	val := ctx.Value(cacheManagerKeyType{})
+	if mgr, ok := val.(contract.CacheManager); ok {
+		return mgr
+	}
+	return nil
 }

--- a/core/timeseries_test.go
+++ b/core/timeseries_test.go
@@ -39,6 +39,7 @@ func TestRunTimeseriesAnalysis_Success(t *testing.T) {
 
 	// Mock the analysis calls for each point (simplified - just return success)
 	mockMgr.On("GetActivityStore").Return(nil).Maybe() // No caching for test
+	mockMgr.On("GetAnalysisStore").Return(nil).Maybe() // No analysis tracking for test
 	mockClient.On("ListFilesAtRef", mock.AnythingOfType("*context.valueCtx"), "/test/repo", "HEAD").Return([]string{path}, nil).Maybe()
 	mockClient.On("GetActivityLog", mock.AnythingOfType("*context.valueCtx"), "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
 		Return([]byte("--abc123|Alice|2024-01-01T00:00:00Z\n1\t0\tmain.go\n"), nil).Maybe()
@@ -83,6 +84,7 @@ func TestRunTimeseriesAnalysis_GetOldestCommitError(t *testing.T) {
 
 	// Setup mock expectations - GetOldestCommitDateForPath fails
 	mockMgr.On("GetActivityStore").Return(nil).Maybe() // No caching for test
+	mockMgr.On("GetAnalysisStore").Return(nil).Maybe() // No analysis tracking for test
 	mockClient.On("GetOldestCommitDateForPath", ctx, "/test/repo", path, mock.AnythingOfType("time.Time"), minCommits, maxSearchDuration).
 		Return(time.Time{}, assert.AnError).Maybe()
 	mockClient.On("ListFilesAtRef", mock.AnythingOfType("*context.valueCtx"), "/test/repo", "HEAD").Return([]string{path}, nil).Maybe()
@@ -119,6 +121,7 @@ func TestAnalyzeTimeseriesPoint_File(t *testing.T) {
 
 	// Setup mock expectations
 	mockMgr.On("GetActivityStore").Return(nil) // No caching for test
+	mockMgr.On("GetAnalysisStore").Return(nil) // No analysis tracking for test
 	mockClient.On("ListFilesAtRef", mock.AnythingOfType("*context.valueCtx"), "/test/repo", "HEAD").Return([]string{path}, nil)
 	mockClient.On("GetActivityLog", mock.AnythingOfType("*context.valueCtx"), "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
 		Return([]byte("--abc123|Alice|2024-01-01T00:00:00Z\n1\t0\tmain.go\n"), nil)
@@ -150,6 +153,7 @@ func TestAnalyzeTimeseriesPoint_Folder(t *testing.T) {
 
 	// Setup mock expectations
 	mockMgr.On("GetActivityStore").Return(nil) // No caching for test
+	mockMgr.On("GetAnalysisStore").Return(nil) // No analysis tracking for test
 	mockClient.On("ListFilesAtRef", mock.AnythingOfType("*context.valueCtx"), "/test/repo", "HEAD").Return([]string{"src/main.go", "src/utils.go"}, nil)
 	mockClient.On("GetActivityLog", mock.AnythingOfType("*context.valueCtx"), "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
 		Return([]byte("--abc123|Alice|2024-01-01T00:00:00Z\n1\t0\tsrc/main.go\n2\t1\tsrc/utils.go\n"), nil)
@@ -182,6 +186,7 @@ func TestAnalyzeTimeseriesPoint_NoData(t *testing.T) {
 
 	// Setup mock expectations - no files found
 	mockMgr.On("GetActivityStore").Return(nil) // No caching for test
+	mockMgr.On("GetAnalysisStore").Return(nil) // No analysis tracking for test
 	mockClient.On("ListFilesAtRef", mock.AnythingOfType("*context.valueCtx"), "/test/repo", "HEAD").Return([]string{}, nil)
 	mockClient.On("GetActivityLog", mock.AnythingOfType("*context.valueCtx"), "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
 		Return([]byte(""), nil)
@@ -212,6 +217,7 @@ func TestAnalyzeTimeseriesPoint_PathNotFound(t *testing.T) {
 
 	// Setup mock expectations - file exists but path not found in results
 	mockMgr.On("GetActivityStore").Return(nil) // No caching for test
+	mockMgr.On("GetAnalysisStore").Return(nil) // No analysis tracking for test
 	mockClient.On("ListFilesAtRef", mock.AnythingOfType("*context.valueCtx"), "/test/repo", "HEAD").Return([]string{"other.go"}, nil)
 	mockClient.On("GetActivityLog", mock.AnythingOfType("*context.valueCtx"), "/test/repo", mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
 		Return([]byte("--abc123|Alice|2024-01-01T00:00:00Z\n1\t0\tother.go\n"), nil)

--- a/examples/hotspot.docs.yml
+++ b/examples/hotspot.docs.yml
@@ -58,6 +58,19 @@
 # PostgreSQL format: host=localhost port=5432 user=postgres password=mysecretpassword dbname=postgres
 # cache-db-connect: ""
 
+# analysis-backend: The backend to use for storing analysis tracking results.
+# Valid values: sqlite, mysql, postgresql, none (empty = disabled)
+# Corresponds to: --analysis-backend
+# Default: "" (disabled)
+# analysis-backend: sqlite
+
+# analysis-db-connect: Database connection string for analysis tracking (mysql/postgresql backends).
+# Must differ from cache-db-connect if both use the same backend type.
+# Corresponds to: --analysis-db-connect
+# MySQL format: user:password@tcp(host:port)/dbname
+# PostgreSQL format: host=localhost port=5432 user=postgres password=mysecretpassword dbname=postgres
+# analysis-db-connect: ""
+
 # emoji: Enable emojis in output headers.
 # Valid values: yes, no, true, false, 1, 0
 # Corresponds to: --emoji

--- a/internal/contract/configs_test.go
+++ b/internal/contract/configs_test.go
@@ -339,6 +339,132 @@ func TestProcessAndValidate(t *testing.T) {
 				mock.On("GetRepoRoot", ctx, workDir).Return("/mock/repo/root", nil)
 			},
 		},
+		{
+			name: "analysis backend sqlite",
+			input: &ConfigRawInput{
+				Limit:             10,
+				Workers:           4,
+				Mode:              string(schema.HotMode),
+				Precision:         1,
+				Output:            "text",
+				Exclude:           "",
+				RepoPathStr:       ".",
+				CacheBackend:      string(schema.SQLiteBackend),
+				AnalysisBackend:   string(schema.SQLiteBackend),
+				AnalysisDBConnect: "analysis.db",
+				Emoji:             "no",
+				Color:             "yes",
+			},
+			expectError: false,
+			setupMock: func(mock *MockGitClient, workDir string) {
+				ctx := context.Background()
+				mock.On("GetRepoRoot", ctx, workDir).Return("/mock/repo/root", nil)
+			},
+		},
+		{
+			name: "analysis backend mysql with connection string",
+			input: &ConfigRawInput{
+				Limit:             10,
+				Workers:           4,
+				Mode:              string(schema.HotMode),
+				Precision:         1,
+				Output:            "text",
+				Exclude:           "",
+				RepoPathStr:       ".",
+				CacheBackend:      string(schema.MySQLBackend),
+				CacheDBConnect:    "user:pass@tcp(localhost:3306)/cache",
+				AnalysisBackend:   string(schema.MySQLBackend),
+				AnalysisDBConnect: "user:pass@tcp(localhost:3306)/analysis",
+				Emoji:             "no",
+				Color:             "yes",
+			},
+			expectError: false,
+			setupMock: func(mock *MockGitClient, workDir string) {
+				ctx := context.Background()
+				mock.On("GetRepoRoot", ctx, workDir).Return("/mock/repo/root", nil)
+			},
+		},
+		{
+			name: "analysis backend same as cache backend with different db",
+			input: &ConfigRawInput{
+				Limit:             10,
+				Workers:           4,
+				Mode:              string(schema.HotMode),
+				Precision:         1,
+				Output:            "text",
+				Exclude:           "",
+				RepoPathStr:       ".",
+				CacheBackend:      string(schema.MySQLBackend),
+				CacheDBConnect:    "user:pass@tcp(localhost:3306)/cache",
+				AnalysisBackend:   string(schema.MySQLBackend),
+				AnalysisDBConnect: "user:pass@tcp(localhost:3306)/analysis",
+				Emoji:             "no",
+				Color:             "yes",
+			},
+			expectError: false,
+			setupMock: func(mock *MockGitClient, workDir string) {
+				ctx := context.Background()
+				mock.On("GetRepoRoot", ctx, workDir).Return("/mock/repo/root", nil)
+			},
+		},
+		{
+			name: "analysis backend same as cache backend with same db should fail",
+			input: &ConfigRawInput{
+				Limit:             10,
+				Workers:           4,
+				Mode:              string(schema.HotMode),
+				Precision:         1,
+				Output:            "text",
+				Exclude:           "",
+				RepoPathStr:       ".",
+				CacheBackend:      string(schema.MySQLBackend),
+				CacheDBConnect:    "user:pass@tcp(localhost:3306)/hotspot",
+				AnalysisBackend:   string(schema.MySQLBackend),
+				AnalysisDBConnect: "user:pass@tcp(localhost:3306)/hotspot",
+				Emoji:             "no",
+				Color:             "yes",
+			},
+			expectError: true,
+			setupMock:   nil,
+		},
+		{
+			name: "invalid analysis backend",
+			input: &ConfigRawInput{
+				Limit:           10,
+				Workers:         4,
+				Mode:            string(schema.HotMode),
+				Precision:       1,
+				Output:          "text",
+				Exclude:         "",
+				RepoPathStr:     ".",
+				CacheBackend:    string(schema.SQLiteBackend),
+				AnalysisBackend: "invalid_backend",
+				Emoji:           "no",
+				Color:           "yes",
+			},
+			expectError: true,
+			setupMock:   nil,
+		},
+		{
+			name: "both sqlite with same explicit database path should fail",
+			input: &ConfigRawInput{
+				Limit:             10,
+				Workers:           4,
+				Mode:              string(schema.HotMode),
+				Precision:         1,
+				Output:            "text",
+				Exclude:           "",
+				RepoPathStr:       ".",
+				CacheBackend:      string(schema.SQLiteBackend),
+				CacheDBConnect:    "/tmp/same.db",
+				AnalysisBackend:   string(schema.SQLiteBackend),
+				AnalysisDBConnect: "/tmp/same.db",
+				Emoji:             "no",
+				Color:             "yes",
+			},
+			expectError: true,
+			setupMock:   nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/contract/utils.go
+++ b/internal/contract/utils.go
@@ -111,7 +111,7 @@ func ShouldIgnore(path string, excludes []string) bool {
 	return false
 }
 
-// LogFatal logs an error and exits the program.
+// LogFatal logs a fatal error message to stderr and exits the program.
 func LogFatal(msg string, err error) {
 	log.Fatalf("%s: %v", msg, err)
 }

--- a/internal/contract/utils.go
+++ b/internal/contract/utils.go
@@ -112,18 +112,32 @@ func ShouldIgnore(path string, excludes []string) bool {
 
 // LogFatal logs an error and exits the program.
 func LogFatal(msg string, err error) {
-	_, _ = fmt.Fprintf(os.Stderr, "%s: %v\n", msg, err)
+	_, _ = fmt.Fprintf(os.Stderr, "Fatal %s: %v\n", msg, err)
 	os.Exit(1)
 }
 
-// GetDBFilePath returns the path to the SQLite DB file.
-func GetDBFilePath() string {
+// LogWarn logs a warning message to stderr.
+func LogWarn(msg string, err error) {
+	_, _ = fmt.Fprintf(os.Stderr, "Warn %s: %v\n", msg, err)
+}
+
+// GetCacheDBFilePath returns the path to the SQLite DB file for cache storage.
+func GetCacheDBFilePath() string {
 	// Implementation from internal/persist_global.go
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return ".hotspot_cache.db"
 	}
 	return filepath.Join(homeDir, ".hotspot_cache.db")
+}
+
+// GetAnalysisDBFilePath returns the path to the SQLite DB file for analysis storage.
+func GetAnalysisDBFilePath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ".hotspot_analysis.db"
+	}
+	return filepath.Join(homeDir, ".hotspot_analysis.db")
 }
 
 // NormalizeTimeseriesPath normalizes a user-provided path relative to the repo root

--- a/internal/contract/utils.go
+++ b/internal/contract/utils.go
@@ -2,6 +2,7 @@ package contract
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,13 +113,12 @@ func ShouldIgnore(path string, excludes []string) bool {
 
 // LogFatal logs an error and exits the program.
 func LogFatal(msg string, err error) {
-	_, _ = fmt.Fprintf(os.Stderr, "Fatal %s: %v\n", msg, err)
-	os.Exit(1)
+	log.Fatalf("%s: %v", msg, err)
 }
 
 // LogWarn logs a warning message to stderr.
 func LogWarn(msg string, err error) {
-	_, _ = fmt.Fprintf(os.Stderr, "Warn %s: %v\n", msg, err)
+	log.Printf("%s: %v", msg, err)
 }
 
 // GetCacheDBFilePath returns the path to the SQLite DB file for cache storage.

--- a/internal/contract/utils_test.go
+++ b/internal/contract/utils_test.go
@@ -168,14 +168,29 @@ func TestShouldIgnore(t *testing.T) {
 	}
 }
 
-func TestGetDBFilePath(t *testing.T) {
-	path := GetDBFilePath()
+func TestGetCacheDBFilePath(t *testing.T) {
+	path := GetCacheDBFilePath()
 
 	// Should not be empty
 	assert.NotEmpty(t, path)
 
 	// Should contain the database name
 	assert.Contains(t, path, ".hotspot_cache.db")
+
+	// Should be in home directory
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(path, homeDir), "path %s should start with home dir %s", path, homeDir)
+}
+
+func TestGetAnalysisDBFilePath(t *testing.T) {
+	path := GetAnalysisDBFilePath()
+
+	// Should not be empty
+	assert.NotEmpty(t, path)
+
+	// Should contain the database name
+	assert.Contains(t, path, ".hotspot_analysis.db")
 
 	// Should be in home directory
 	homeDir, err := os.UserHomeDir()

--- a/internal/iocache/analysis_store.go
+++ b/internal/iocache/analysis_store.go
@@ -1,0 +1,486 @@
+package iocache
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/huangsam/hotspot/internal/contract"
+	"github.com/huangsam/hotspot/schema"
+)
+
+// Table names for analysis tracking.
+const (
+	analysisRunsTable  = "hotspot_analysis_runs"
+	rawGitMetricsTable = "hotspot_raw_git_metrics"
+	finalScoresTable   = "hotspot_final_scores"
+)
+
+// AnalysisStoreImpl implements the AnalysisStore interface.
+type AnalysisStoreImpl struct {
+	db         *sql.DB
+	backend    schema.CacheBackend
+	driverName string
+}
+
+var _ contract.AnalysisStore = &AnalysisStoreImpl{} // Compile-time check
+
+// NewAnalysisStore creates a new AnalysisStore with the specified backend.
+func NewAnalysisStore(backend schema.CacheBackend, connStr string) (contract.AnalysisStore, error) {
+	var db *sql.DB
+	var err error
+	var driverName string
+
+	switch backend {
+	case schema.SQLiteBackend:
+		driverName = "sqlite3"
+		dbPath := connStr
+		if dbPath == "" {
+			dbPath = GetAnalysisDBFilePath()
+		}
+		db, err = sql.Open(driverName, dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open SQLite database: %w", err)
+		}
+		// Limit SQLite to a single open connection to avoid "database is locked" errors
+		db.SetMaxOpenConns(1)
+
+	case schema.MySQLBackend:
+		driverName = "mysql"
+		db, err = sql.Open(driverName, connStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open MySQL database: %w", err)
+		}
+
+	case schema.PostgreSQLBackend:
+		driverName = "pgx"
+		db, err = sql.Open(driverName, connStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open PostgreSQL database: %w", err)
+		}
+
+	case schema.NoneBackend:
+		// Return a no-op store for disabled tracking
+		return &AnalysisStoreImpl{
+			db:         nil,
+			backend:    backend,
+			driverName: "",
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported backend: %s", backend)
+	}
+
+	// Ping to verify connection
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to ping %s database: %w", backend, err)
+	}
+
+	// Create the table schemas
+	if err := createAnalysisTables(db, backend); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to create analysis tables: %w", err)
+	}
+
+	return &AnalysisStoreImpl{
+		db:         db,
+		backend:    backend,
+		driverName: driverName,
+	}, nil
+}
+
+// createAnalysisTables creates all three analysis tracking tables.
+func createAnalysisTables(db *sql.DB, backend schema.CacheBackend) error {
+	tables := []struct {
+		name  string
+		query string
+	}{
+		{analysisRunsTable, getCreateAnalysisRunsQuery(backend)},
+		{rawGitMetricsTable, getCreateRawGitMetricsQuery(backend)},
+		{finalScoresTable, getCreateFinalScoresQuery(backend)},
+	}
+
+	for _, table := range tables {
+		if _, err := db.Exec(table.query); err != nil {
+			return fmt.Errorf("failed to create table %s: %w", table.name, err)
+		}
+	}
+
+	return nil
+}
+
+// getCreateAnalysisRunsQuery returns the CREATE TABLE query for hotspot_analysis_runs.
+func getCreateAnalysisRunsQuery(backend schema.CacheBackend) string {
+	quotedTableName := quoteTableName(analysisRunsTable, backend)
+
+	switch backend {
+	case schema.MySQLBackend:
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				analysis_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+				start_time DATETIME(6) NOT NULL,
+				end_time DATETIME(6),
+				run_duration_ms INT,
+				total_files_analyzed INT,
+				config_params TEXT
+			);
+		`, quotedTableName)
+
+	case schema.PostgreSQLBackend:
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				analysis_id BIGSERIAL PRIMARY KEY,
+				start_time TIMESTAMPTZ NOT NULL,
+				end_time TIMESTAMPTZ,
+				run_duration_ms INT,
+				total_files_analyzed INT,
+				config_params TEXT
+			);
+		`, quotedTableName)
+
+	default: // SQLite
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				analysis_id INTEGER PRIMARY KEY AUTOINCREMENT,
+				start_time TEXT NOT NULL,
+				end_time TEXT,
+				run_duration_ms INTEGER,
+				total_files_analyzed INTEGER,
+				config_params TEXT
+			);
+		`, quotedTableName)
+	}
+}
+
+// getCreateRawGitMetricsQuery returns the CREATE TABLE query for hotspot_raw_git_metrics.
+func getCreateRawGitMetricsQuery(backend schema.CacheBackend) string {
+	quotedTableName := quoteTableName(rawGitMetricsTable, backend)
+
+	switch backend {
+	case schema.MySQLBackend:
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				analysis_id BIGINT NOT NULL,
+				file_path VARCHAR(512) NOT NULL,
+				analysis_time DATETIME(6) NOT NULL,
+				total_commits INT NOT NULL,
+				total_churn INT NOT NULL,
+				contributor_count INT NOT NULL,
+				age_days DOUBLE NOT NULL,
+				gini_coefficient DOUBLE NOT NULL,
+				file_owner VARCHAR(100),
+				PRIMARY KEY (analysis_id, file_path)
+			);
+		`, quotedTableName)
+
+	case schema.PostgreSQLBackend:
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				analysis_id BIGINT NOT NULL,
+				file_path TEXT NOT NULL,
+				analysis_time TIMESTAMPTZ NOT NULL,
+				total_commits INT NOT NULL,
+				total_churn INT NOT NULL,
+				contributor_count INT NOT NULL,
+				age_days DOUBLE PRECISION NOT NULL,
+				gini_coefficient DOUBLE PRECISION NOT NULL,
+				file_owner TEXT,
+				PRIMARY KEY (analysis_id, file_path)
+			);
+		`, quotedTableName)
+
+	default: // SQLite
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				analysis_id INTEGER NOT NULL,
+				file_path TEXT NOT NULL,
+				analysis_time TEXT NOT NULL,
+				total_commits INTEGER NOT NULL,
+				total_churn INTEGER NOT NULL,
+				contributor_count INTEGER NOT NULL,
+				age_days REAL NOT NULL,
+				gini_coefficient REAL NOT NULL,
+				file_owner TEXT,
+				PRIMARY KEY (analysis_id, file_path)
+			);
+		`, quotedTableName)
+	}
+}
+
+// getCreateFinalScoresQuery returns the CREATE TABLE query for hotspot_final_scores.
+func getCreateFinalScoresQuery(backend schema.CacheBackend) string {
+	quotedTableName := quoteTableName(finalScoresTable, backend)
+
+	switch backend {
+	case schema.MySQLBackend:
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				analysis_id BIGINT NOT NULL,
+				file_path VARCHAR(512) NOT NULL,
+				analysis_time DATETIME(6) NOT NULL,
+				score_hot DOUBLE NOT NULL,
+				score_risk DOUBLE NOT NULL,
+				score_complexity DOUBLE NOT NULL,
+				score_stale DOUBLE NOT NULL,
+				score_label VARCHAR(50) NOT NULL,
+				PRIMARY KEY (analysis_id, file_path)
+			);
+		`, quotedTableName)
+
+	case schema.PostgreSQLBackend:
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				analysis_id BIGINT NOT NULL,
+				file_path TEXT NOT NULL,
+				analysis_time TIMESTAMPTZ NOT NULL,
+				score_hot DOUBLE PRECISION NOT NULL,
+				score_risk DOUBLE PRECISION NOT NULL,
+				score_complexity DOUBLE PRECISION NOT NULL,
+				score_stale DOUBLE PRECISION NOT NULL,
+				score_label TEXT NOT NULL,
+				PRIMARY KEY (analysis_id, file_path)
+			);
+		`, quotedTableName)
+
+	default: // SQLite
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				analysis_id INTEGER NOT NULL,
+				file_path TEXT NOT NULL,
+				analysis_time TEXT NOT NULL,
+				score_hot REAL NOT NULL,
+				score_risk REAL NOT NULL,
+				score_complexity REAL NOT NULL,
+				score_stale REAL NOT NULL,
+				score_label TEXT NOT NULL,
+				PRIMARY KEY (analysis_id, file_path)
+			);
+		`, quotedTableName)
+	}
+}
+
+// BeginAnalysis creates a new analysis run and returns its unique ID.
+func (as *AnalysisStoreImpl) BeginAnalysis(startTime time.Time, configParams map[string]any) (int64, error) {
+	// Skip for NoneBackend
+	if as.backend == schema.NoneBackend || as.db == nil {
+		return 0, nil
+	}
+
+	// Serialize config params to JSON
+	configJSON, err := json.Marshal(configParams)
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal config params: %w", err)
+	}
+
+	quotedTableName := quoteTableName(analysisRunsTable, as.backend)
+
+	var analysisID int64
+	switch as.backend {
+	case schema.PostgreSQLBackend:
+		query := fmt.Sprintf(`INSERT INTO %s (start_time, config_params) VALUES ($1, $2) RETURNING analysis_id`, quotedTableName)
+		err = as.db.QueryRow(query, startTime, string(configJSON)).Scan(&analysisID)
+	default: // SQLite and MySQL
+		query := fmt.Sprintf(`INSERT INTO %s (start_time, config_params) VALUES (?, ?)`, quotedTableName)
+		var result sql.Result
+		result, err = as.db.Exec(query, formatTime(startTime, as.backend), string(configJSON))
+		if err != nil {
+			return 0, err
+		}
+		analysisID, err = result.LastInsertId()
+	}
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to insert analysis run: %w", err)
+	}
+
+	return analysisID, nil
+}
+
+// EndAnalysis updates the analysis run with completion data.
+func (as *AnalysisStoreImpl) EndAnalysis(analysisID int64, endTime time.Time, totalFiles int) error {
+	// Skip for NoneBackend
+	if as.backend == schema.NoneBackend || as.db == nil {
+		return nil
+	}
+
+	// First, get the start_time to calculate duration
+	quotedTableName := quoteTableName(analysisRunsTable, as.backend)
+	var startTime time.Time
+
+	var query string
+	switch as.backend {
+	case schema.PostgreSQLBackend:
+		query = fmt.Sprintf(`SELECT start_time FROM %s WHERE analysis_id = $1`, quotedTableName)
+	default: // SQLite and MySQL
+		query = fmt.Sprintf(`SELECT start_time FROM %s WHERE analysis_id = ?`, quotedTableName)
+	}
+
+	row := as.db.QueryRow(query, analysisID)
+
+	// Handle different time storage formats per backend
+	switch as.backend {
+	case schema.SQLiteBackend:
+		var startTimeStr string
+		if err := row.Scan(&startTimeStr); err != nil {
+			return fmt.Errorf("failed to get start_time for analysis %d: %w", analysisID, err)
+		}
+		var err error
+		startTime, err = time.Parse(time.RFC3339Nano, startTimeStr)
+		if err != nil {
+			return fmt.Errorf("failed to parse start_time: %w", err)
+		}
+	default: // MySQL and PostgreSQL store as native datetime
+		if err := row.Scan(&startTime); err != nil {
+			return fmt.Errorf("failed to get start_time for analysis %d: %w", analysisID, err)
+		}
+	}
+
+	// Calculate duration in milliseconds
+	durationMs := endTime.Sub(startTime).Milliseconds()
+
+	// Update the analysis run with completion data
+	var updateQuery string
+	var args []any
+
+	switch as.backend {
+	case schema.PostgreSQLBackend:
+		updateQuery = fmt.Sprintf(`UPDATE %s SET end_time = $1, run_duration_ms = $2, total_files_analyzed = $3 WHERE analysis_id = $4`, quotedTableName)
+		args = []any{endTime, durationMs, totalFiles, analysisID}
+	default: // SQLite and MySQL
+		updateQuery = fmt.Sprintf(`UPDATE %s SET end_time = ?, run_duration_ms = ?, total_files_analyzed = ? WHERE analysis_id = ?`, quotedTableName)
+		args = []any{formatTime(endTime, as.backend), durationMs, totalFiles, analysisID}
+	}
+
+	_, err := as.db.Exec(updateQuery, args...)
+	if err != nil {
+		return fmt.Errorf("failed to update analysis run: %w", err)
+	}
+
+	return nil
+}
+
+// RecordFileMetrics stores raw git metrics for a file.
+func (as *AnalysisStoreImpl) RecordFileMetrics(analysisID int64, filePath string, metrics schema.FileMetrics) error {
+	// Skip for NoneBackend
+	if as.backend == schema.NoneBackend || as.db == nil {
+		return nil
+	}
+
+	quotedTableName := quoteTableName(rawGitMetricsTable, as.backend)
+
+	var query string
+	var args []any
+
+	switch as.backend {
+	case schema.MySQLBackend:
+		query = fmt.Sprintf(`
+			INSERT INTO %s (analysis_id, file_path, analysis_time, total_commits, total_churn,
+			                 contributor_count, age_days, gini_coefficient, file_owner)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, quotedTableName)
+		args = []any{
+			analysisID, filePath, metrics.AnalysisTime, metrics.TotalCommits, metrics.TotalChurn,
+			metrics.ContributorCount, metrics.AgeDays, metrics.GiniCoefficient, metrics.FileOwner,
+		}
+	case schema.PostgreSQLBackend:
+		query = fmt.Sprintf(`
+			INSERT INTO %s (analysis_id, file_path, analysis_time, total_commits, total_churn,
+			                 contributor_count, age_days, gini_coefficient, file_owner)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		`, quotedTableName)
+		args = []any{
+			analysisID, filePath, metrics.AnalysisTime, metrics.TotalCommits, metrics.TotalChurn,
+			metrics.ContributorCount, metrics.AgeDays, metrics.GiniCoefficient, metrics.FileOwner,
+		}
+	default: // SQLite
+		query = fmt.Sprintf(`
+			INSERT INTO %s (analysis_id, file_path, analysis_time, total_commits, total_churn,
+			                 contributor_count, age_days, gini_coefficient, file_owner)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, quotedTableName)
+		args = []any{
+			analysisID, filePath, metrics.AnalysisTime, metrics.TotalCommits, metrics.TotalChurn,
+			metrics.ContributorCount, metrics.AgeDays, metrics.GiniCoefficient, metrics.FileOwner,
+		}
+	}
+
+	_, err := as.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to insert file metrics: %w", err)
+	}
+
+	return nil
+}
+
+// RecordFileScores stores final scores for a file.
+func (as *AnalysisStoreImpl) RecordFileScores(analysisID int64, filePath string, scores schema.FileScores) error {
+	// Skip for NoneBackend
+	if as.backend == schema.NoneBackend || as.db == nil {
+		return nil
+	}
+
+	quotedTableName := quoteTableName(finalScoresTable, as.backend)
+
+	var query string
+	var args []any
+
+	switch as.backend {
+	case schema.MySQLBackend:
+		query = fmt.Sprintf(`
+			INSERT INTO %s (analysis_id, file_path, analysis_time, score_hot, score_risk,
+			                 score_complexity, score_stale, score_label)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`, quotedTableName)
+		args = []any{
+			analysisID, filePath, formatTime(scores.AnalysisTime, as.backend), scores.HotScore, scores.RiskScore,
+			scores.ComplexityScore, scores.StaleScore, scores.ScoreLabel,
+		}
+	case schema.PostgreSQLBackend:
+		query = fmt.Sprintf(`
+			INSERT INTO %s (analysis_id, file_path, analysis_time, score_hot, score_risk,
+			                 score_complexity, score_stale, score_label)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		`, quotedTableName)
+		args = []any{
+			analysisID, filePath, formatTime(scores.AnalysisTime, as.backend), scores.HotScore, scores.RiskScore,
+			scores.ComplexityScore, scores.StaleScore, scores.ScoreLabel,
+		}
+	default: // SQLite
+		query = fmt.Sprintf(`
+			INSERT INTO %s (analysis_id, file_path, analysis_time, score_hot, score_risk,
+			                 score_complexity, score_stale, score_label)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`, quotedTableName)
+		args = []any{
+			analysisID, filePath, formatTime(scores.AnalysisTime, as.backend), scores.HotScore, scores.RiskScore,
+			scores.ComplexityScore, scores.StaleScore, scores.ScoreLabel,
+		}
+	}
+
+	_, err := as.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to insert file scores: %w", err)
+	}
+
+	return nil
+}
+
+// Close closes the underlying connection.
+func (as *AnalysisStoreImpl) Close() error {
+	if as.db != nil {
+		return as.db.Close()
+	}
+	return nil
+}
+
+// formatTime converts a time.Time to the appropriate format for the backend.
+func formatTime(t time.Time, backend schema.CacheBackend) any {
+	switch backend {
+	case schema.SQLiteBackend:
+		return t.Format(time.RFC3339Nano)
+	default:
+		return t
+	}
+}

--- a/internal/iocache/analysis_store.go
+++ b/internal/iocache/analysis_store.go
@@ -373,6 +373,7 @@ func (as *AnalysisStoreImpl) RecordFileMetrics(analysisID int64, filePath string
 	var query string
 	var args []any
 
+	analysisTime := formatTime(metrics.AnalysisTime, as.backend)
 	switch as.backend {
 	case schema.MySQLBackend:
 		query = fmt.Sprintf(`
@@ -381,7 +382,7 @@ func (as *AnalysisStoreImpl) RecordFileMetrics(analysisID int64, filePath string
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, quotedTableName)
 		args = []any{
-			analysisID, filePath, metrics.AnalysisTime, metrics.TotalCommits, metrics.TotalChurn,
+			analysisID, filePath, analysisTime, metrics.TotalCommits, metrics.TotalChurn,
 			metrics.ContributorCount, metrics.AgeDays, metrics.GiniCoefficient, metrics.FileOwner,
 		}
 	case schema.PostgreSQLBackend:
@@ -391,7 +392,7 @@ func (as *AnalysisStoreImpl) RecordFileMetrics(analysisID int64, filePath string
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		`, quotedTableName)
 		args = []any{
-			analysisID, filePath, metrics.AnalysisTime, metrics.TotalCommits, metrics.TotalChurn,
+			analysisID, filePath, analysisTime, metrics.TotalCommits, metrics.TotalChurn,
 			metrics.ContributorCount, metrics.AgeDays, metrics.GiniCoefficient, metrics.FileOwner,
 		}
 	default: // SQLite
@@ -401,7 +402,7 @@ func (as *AnalysisStoreImpl) RecordFileMetrics(analysisID int64, filePath string
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, quotedTableName)
 		args = []any{
-			analysisID, filePath, metrics.AnalysisTime, metrics.TotalCommits, metrics.TotalChurn,
+			analysisID, filePath, analysisTime, metrics.TotalCommits, metrics.TotalChurn,
 			metrics.ContributorCount, metrics.AgeDays, metrics.GiniCoefficient, metrics.FileOwner,
 		}
 	}
@@ -426,6 +427,7 @@ func (as *AnalysisStoreImpl) RecordFileScores(analysisID int64, filePath string,
 	var query string
 	var args []any
 
+	analysisTime := formatTime(scores.AnalysisTime, as.backend)
 	switch as.backend {
 	case schema.MySQLBackend:
 		query = fmt.Sprintf(`
@@ -434,7 +436,7 @@ func (as *AnalysisStoreImpl) RecordFileScores(analysisID int64, filePath string,
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		`, quotedTableName)
 		args = []any{
-			analysisID, filePath, formatTime(scores.AnalysisTime, as.backend), scores.HotScore, scores.RiskScore,
+			analysisID, filePath, analysisTime, scores.HotScore, scores.RiskScore,
 			scores.ComplexityScore, scores.StaleScore, scores.ScoreLabel,
 		}
 	case schema.PostgreSQLBackend:
@@ -444,7 +446,7 @@ func (as *AnalysisStoreImpl) RecordFileScores(analysisID int64, filePath string,
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		`, quotedTableName)
 		args = []any{
-			analysisID, filePath, formatTime(scores.AnalysisTime, as.backend), scores.HotScore, scores.RiskScore,
+			analysisID, filePath, analysisTime, scores.HotScore, scores.RiskScore,
 			scores.ComplexityScore, scores.StaleScore, scores.ScoreLabel,
 		}
 	default: // SQLite
@@ -454,7 +456,7 @@ func (as *AnalysisStoreImpl) RecordFileScores(analysisID int64, filePath string,
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		`, quotedTableName)
 		args = []any{
-			analysisID, filePath, formatTime(scores.AnalysisTime, as.backend), scores.HotScore, scores.RiskScore,
+			analysisID, filePath, analysisTime, scores.HotScore, scores.RiskScore,
 			scores.ComplexityScore, scores.StaleScore, scores.ScoreLabel,
 		}
 	}

--- a/internal/iocache/analysis_store_test.go
+++ b/internal/iocache/analysis_store_test.go
@@ -1,0 +1,258 @@
+package iocache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/huangsam/hotspot/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalysisStore_NoneBackend(t *testing.T) {
+	store, err := NewAnalysisStore(schema.NoneBackend, "")
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	// BeginAnalysis should return 0 for NoneBackend
+	analysisID, err := store.BeginAnalysis(time.Now(), map[string]any{"test": "value"})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), analysisID)
+
+	// Other operations should not error
+	err = store.EndAnalysis(1, time.Now(), 10)
+	assert.NoError(t, err)
+
+	err = store.RecordFileMetrics(1, "test.go", schema.FileMetrics{})
+	assert.NoError(t, err)
+
+	err = store.RecordFileScores(1, "test.go", schema.FileScores{})
+	assert.NoError(t, err)
+
+	err = store.Close()
+	assert.NoError(t, err)
+}
+
+func TestAnalysisStore_SQLite(t *testing.T) {
+	// Use in-memory SQLite for testing
+	store, err := NewAnalysisStore(schema.SQLiteBackend, ":memory:")
+	require.NoError(t, err)
+	require.NotNil(t, store)
+	defer func() { _ = store.Close() }()
+
+	// Test BeginAnalysis
+	startTime := time.Now()
+	configParams := map[string]any{
+		"mode":      "hot",
+		"lookback":  "30d",
+		"repo_path": "/test/repo",
+	}
+	analysisID, err := store.BeginAnalysis(startTime, configParams)
+	require.NoError(t, err)
+	assert.Greater(t, analysisID, int64(0))
+
+	// Test RecordFileMetrics
+	metrics := schema.FileMetrics{
+		AnalysisTime:     time.Now(),
+		TotalCommits:     100,
+		TotalChurn:       500,
+		ContributorCount: 5,
+		AgeDays:          365.0,
+		GiniCoefficient:  0.5,
+		FileOwner:        "test-owner",
+	}
+	err = store.RecordFileMetrics(analysisID, "test/file.go", metrics)
+	assert.NoError(t, err)
+
+	// Test RecordFileScores
+	scores := schema.FileScores{
+		AnalysisTime:    time.Now(),
+		HotScore:        75.5,
+		RiskScore:       80.2,
+		ComplexityScore: 65.3,
+		StaleScore:      70.1,
+		ScoreLabel:      "hot",
+	}
+	err = store.RecordFileScores(analysisID, "test/file.go", scores)
+	assert.NoError(t, err)
+
+	// Test EndAnalysis
+	endTime := time.Now()
+	err = store.EndAnalysis(analysisID, endTime, 1)
+	assert.NoError(t, err)
+}
+
+func TestAnalysisStore_MultipleFiles(t *testing.T) {
+	store, err := NewAnalysisStore(schema.SQLiteBackend, ":memory:")
+	require.NoError(t, err)
+	require.NotNil(t, store)
+	defer func() { _ = store.Close() }()
+
+	// Begin analysis
+	analysisID, err := store.BeginAnalysis(time.Now(), map[string]any{"test": "multi-file"})
+	require.NoError(t, err)
+
+	// Record multiple files
+	files := []string{"file1.go", "file2.go", "file3.go"}
+	for _, file := range files {
+		metrics := schema.FileMetrics{
+			AnalysisTime:     time.Now(),
+			TotalCommits:     100,
+			TotalChurn:       500,
+			ContributorCount: 5,
+			AgeDays:          365.0,
+			GiniCoefficient:  0.5,
+			FileOwner:        "owner",
+		}
+		err = store.RecordFileMetrics(analysisID, file, metrics)
+		assert.NoError(t, err)
+
+		scores := schema.FileScores{
+			AnalysisTime:    time.Now(),
+			HotScore:        75.5,
+			RiskScore:       80.2,
+			ComplexityScore: 65.3,
+			StaleScore:      70.1,
+			ScoreLabel:      "hot",
+		}
+		err = store.RecordFileScores(analysisID, file, scores)
+		assert.NoError(t, err)
+	}
+
+	// End analysis
+	err = store.EndAnalysis(analysisID, time.Now(), len(files))
+	assert.NoError(t, err)
+}
+
+func TestAnalysisStore_MultipleRuns(t *testing.T) {
+	store, err := NewAnalysisStore(schema.SQLiteBackend, ":memory:")
+	require.NoError(t, err)
+	require.NotNil(t, store)
+	defer func() { _ = store.Close() }()
+
+	// Create multiple analysis runs
+	var analysisIDs []int64
+	for i := range 3 {
+		id, err := store.BeginAnalysis(time.Now(), map[string]any{"run": i})
+		require.NoError(t, err)
+		analysisIDs = append(analysisIDs, id)
+
+		// Record a file for each run
+		metrics := schema.FileMetrics{
+			AnalysisTime:     time.Now(),
+			TotalCommits:     100 + i*10,
+			TotalChurn:       500 + i*50,
+			ContributorCount: 5,
+			AgeDays:          365.0,
+			GiniCoefficient:  0.5,
+			FileOwner:        "owner",
+		}
+		err = store.RecordFileMetrics(id, "test.go", metrics)
+		assert.NoError(t, err)
+
+		scores := schema.FileScores{
+			AnalysisTime:    time.Now(),
+			HotScore:        75.5 + float64(i),
+			RiskScore:       80.2 + float64(i),
+			ComplexityScore: 65.3 + float64(i),
+			StaleScore:      70.1 + float64(i),
+			ScoreLabel:      "hot",
+		}
+		err = store.RecordFileScores(id, "test.go", scores)
+		assert.NoError(t, err)
+
+		err = store.EndAnalysis(id, time.Now(), 1)
+		assert.NoError(t, err)
+	}
+
+	// Verify all IDs are unique
+	assert.Equal(t, 3, len(analysisIDs))
+	assert.NotEqual(t, analysisIDs[0], analysisIDs[1])
+	assert.NotEqual(t, analysisIDs[1], analysisIDs[2])
+}
+
+func TestAnalysisStore_RuntimeCapture(t *testing.T) {
+	store, err := NewAnalysisStore(schema.SQLiteBackend, ":memory:")
+	require.NoError(t, err)
+	require.NotNil(t, store)
+	defer func() { _ = store.Close() }()
+
+	t.Run("runtime calculation", func(t *testing.T) {
+		// Start analysis at a known time
+		startTime := time.Now().Add(-100 * time.Millisecond) // Start 100ms ago
+		analysisID, err := store.BeginAnalysis(startTime, map[string]any{"test": "runtime"})
+		require.NoError(t, err)
+
+		// Wait a bit to ensure measurable duration
+		time.Sleep(50 * time.Millisecond)
+
+		// End analysis
+		endTime := time.Now()
+		err = store.EndAnalysis(analysisID, endTime, 1)
+		assert.NoError(t, err)
+
+		// Query the database to verify runtime was captured
+		db := store.(*AnalysisStoreImpl).db
+		var storedStartTime, storedEndTime string
+		var storedDurationMs int64
+
+		row := db.QueryRow("SELECT start_time, end_time, run_duration_ms FROM hotspot_analysis_runs WHERE analysis_id = ?", analysisID)
+		err = row.Scan(&storedStartTime, &storedEndTime, &storedDurationMs)
+		assert.NoError(t, err)
+
+		// Parse stored times
+		storedStart, err := time.Parse(time.RFC3339Nano, storedStartTime)
+		assert.NoError(t, err)
+		storedEnd, err := time.Parse(time.RFC3339Nano, storedEndTime)
+		assert.NoError(t, err)
+
+		// Verify duration calculation: should be approximately end - start
+		expectedDurationMs := storedEnd.Sub(storedStart).Milliseconds()
+		assert.Equal(t, expectedDurationMs, storedDurationMs)
+
+		// Verify duration is reasonable (should be around 150ms ± some tolerance)
+		assert.GreaterOrEqual(t, storedDurationMs, int64(100)) // At least 100ms (our initial offset)
+		assert.LessOrEqual(t, storedDurationMs, int64(300))    // At most 300ms (allowing for test overhead)
+	})
+
+	t.Run("zero duration edge case", func(t *testing.T) {
+		// Test with same start and end time
+		startTime := time.Now()
+		analysisID, err := store.BeginAnalysis(startTime, map[string]any{"test": "zero_duration"})
+		require.NoError(t, err)
+
+		// End immediately with same time
+		err = store.EndAnalysis(analysisID, startTime, 1)
+		assert.NoError(t, err)
+
+		// Verify duration is 0
+		db := store.(*AnalysisStoreImpl).db
+		var storedDurationMs int64
+		row := db.QueryRow("SELECT run_duration_ms FROM hotspot_analysis_runs WHERE analysis_id = ?", analysisID)
+		err = row.Scan(&storedDurationMs)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), storedDurationMs)
+	})
+
+	t.Run("large duration", func(t *testing.T) {
+		// Test with a longer duration
+		startTime := time.Now().Add(-5 * time.Second)
+		analysisID, err := store.BeginAnalysis(startTime, map[string]any{"test": "large_duration"})
+		require.NoError(t, err)
+
+		endTime := time.Now()
+		err = store.EndAnalysis(analysisID, endTime, 1)
+		assert.NoError(t, err)
+
+		// Verify duration is approximately 5 seconds
+		db := store.(*AnalysisStoreImpl).db
+		var storedDurationMs int64
+		row := db.QueryRow("SELECT run_duration_ms FROM hotspot_analysis_runs WHERE analysis_id = ?", analysisID)
+		err = row.Scan(&storedDurationMs)
+		assert.NoError(t, err)
+
+		// Should be around 5000ms ± tolerance
+		assert.GreaterOrEqual(t, storedDurationMs, int64(4900))
+		assert.LessOrEqual(t, storedDurationMs, int64(5100))
+	})
+}

--- a/internal/iocache/cache_mock.go
+++ b/internal/iocache/cache_mock.go
@@ -1,7 +1,10 @@
 package iocache
 
 import (
+	"time"
+
 	"github.com/huangsam/hotspot/internal/contract"
+	"github.com/huangsam/hotspot/schema"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -16,6 +19,13 @@ var _ contract.CacheManager = &MockCacheManager{} // Compile-time check
 func (m *MockCacheManager) GetActivityStore() contract.CacheStore {
 	ret := m.Called()
 	store, _ := ret.Get(0).(contract.CacheStore)
+	return store
+}
+
+// GetAnalysisStore implements the CacheManager interface.
+func (m *MockCacheManager) GetAnalysisStore() contract.AnalysisStore {
+	ret := m.Called()
+	store, _ := ret.Get(0).(contract.AnalysisStore)
 	return store
 }
 
@@ -40,6 +50,43 @@ func (m *MockCacheStore) Set(key string, data []byte, version int, ts int64) err
 
 // Close implements the CacheStore interface.
 func (m *MockCacheStore) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// MockAnalysisStore is a mock implementation of AnalysisStore for testing.
+type MockAnalysisStore struct {
+	mock.Mock
+}
+
+var _ contract.AnalysisStore = &MockAnalysisStore{} // Compile-time check
+
+// BeginAnalysis implements the AnalysisStore interface.
+func (m *MockAnalysisStore) BeginAnalysis(startTime time.Time, configParams map[string]any) (int64, error) {
+	args := m.Called(startTime, configParams)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+// EndAnalysis implements the AnalysisStore interface.
+func (m *MockAnalysisStore) EndAnalysis(analysisID int64, endTime time.Time, totalFiles int) error {
+	args := m.Called(analysisID, endTime, totalFiles)
+	return args.Error(0)
+}
+
+// RecordFileMetrics implements the AnalysisStore interface.
+func (m *MockAnalysisStore) RecordFileMetrics(analysisID int64, filePath string, metrics schema.FileMetrics) error {
+	args := m.Called(analysisID, filePath, metrics)
+	return args.Error(0)
+}
+
+// RecordFileScores implements the AnalysisStore interface.
+func (m *MockAnalysisStore) RecordFileScores(analysisID int64, filePath string, scores schema.FileScores) error {
+	args := m.Called(analysisID, filePath, scores)
+	return args.Error(0)
+}
+
+// Close implements the AnalysisStore interface.
+func (m *MockAnalysisStore) Close() error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/internal/iocache/cache_store.go
+++ b/internal/iocache/cache_store.go
@@ -1,0 +1,207 @@
+// Package iocache is for caching I/O calls.
+package iocache
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/go-sql-driver/mysql" // MySQL driver
+	"github.com/huangsam/hotspot/internal/contract"
+	"github.com/huangsam/hotspot/schema"
+	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver
+	_ "github.com/mattn/go-sqlite3"    // SQLite driver
+)
+
+// CacheStoreImpl handles durable storage operations using various database backends.
+type CacheStoreImpl struct {
+	db         *sql.DB
+	tableName  string
+	backend    schema.CacheBackend
+	driverName string
+}
+
+var _ contract.CacheStore = &CacheStoreImpl{} // Compile-time check
+
+// NewCacheStore initializes and returns a new CacheStore based on the backend type.
+func NewCacheStore(tableName string, backend schema.CacheBackend, connStr string) (contract.CacheStore, error) {
+	// Validate table name to prevent SQL injection
+	if err := validateTableName(tableName); err != nil {
+		return nil, err
+	}
+
+	var db *sql.DB
+	var err error
+	var driverName string
+
+	switch backend {
+	case schema.SQLiteBackend:
+		driverName = "sqlite3"
+		dbPath := connStr
+		if dbPath == "" {
+			dbPath = GetDBFilePath()
+		}
+		db, err = sql.Open(driverName, dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open SQLite database: %w", err)
+		}
+		// Limit SQLite to a single open connection to avoid "database is locked" errors
+		db.SetMaxOpenConns(1)
+
+	case schema.MySQLBackend:
+		// connStr should be:
+		// user:password@tcp(host:port)/dbname
+		driverName = "mysql"
+		db, err = sql.Open(driverName, connStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open MySQL database: %w", err)
+		}
+
+	case schema.PostgreSQLBackend:
+		// connStr should be:
+		// host=localhost port=5432 user=postgres password=mysecretpassword dbname=postgres
+		driverName = "pgx"
+		db, err = sql.Open(driverName, connStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open PostgreSQL database: %w", err)
+		}
+
+	case schema.NoneBackend:
+		// Return a no-op store for disabled caching
+		return &CacheStoreImpl{
+			db:         nil,
+			tableName:  tableName,
+			backend:    backend,
+			driverName: "",
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported cache backend: %s", backend)
+	}
+
+	// Ping to verify connection (skip for NoneBackend)
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to ping %s database: %w", backend, err)
+	}
+
+	// Create the table schema
+	query := getCreateTableQuery(tableName, backend)
+	if _, err := db.Exec(query); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to create table %s: %w", tableName, err)
+	}
+
+	return &CacheStoreImpl{
+		db:         db,
+		tableName:  tableName,
+		backend:    backend,
+		driverName: driverName,
+	}, nil
+}
+
+// getCreateTableQuery returns the CREATE TABLE query for the given backend.
+func getCreateTableQuery(tableName string, backend schema.CacheBackend) string {
+	quotedTableName := quoteTableName(tableName, backend)
+	switch backend {
+	case schema.MySQLBackend:
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				cache_key VARCHAR(255) PRIMARY KEY,
+				cache_value BLOB NOT NULL,
+				cache_version INT NOT NULL,
+				cache_timestamp BIGINT NOT NULL
+			);
+		`, quotedTableName)
+
+	case schema.PostgreSQLBackend:
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				cache_key TEXT PRIMARY KEY,
+				cache_value BYTEA NOT NULL,
+				cache_version INTEGER NOT NULL,
+				cache_timestamp BIGINT NOT NULL
+			);
+		`, quotedTableName)
+
+	default: // SQLite
+		return fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				cache_key TEXT PRIMARY KEY,
+				cache_value BLOB NOT NULL,
+				cache_version INTEGER NOT NULL,
+				cache_timestamp INTEGER NOT NULL
+			);
+		`, quotedTableName)
+	}
+}
+
+// Get retrieves a value by key from the store.
+func (ps *CacheStoreImpl) Get(key string) ([]byte, int, int64, error) {
+	// Return not found error for NoneBackend
+	if ps.backend == schema.NoneBackend || ps.db == nil {
+		return nil, 0, 0, sql.ErrNoRows
+	}
+
+	var value []byte
+	var version int
+	var ts int64
+
+	// Use backend-specific placeholder
+	quotedTableName := quoteTableName(ps.tableName, ps.backend)
+	placeholder := ps.getPlaceholder()
+	query := fmt.Sprintf(`SELECT cache_value, cache_version, cache_timestamp FROM %s WHERE cache_key = %s`, quotedTableName, placeholder)
+	row := ps.db.QueryRow(query, key)
+
+	if err := row.Scan(&value, &version, &ts); err != nil {
+		return nil, 0, 0, err
+	}
+	return value, version, ts, nil
+}
+
+// Set inserts or replaces a key/value pair in the store.
+func (ps *CacheStoreImpl) Set(key string, value []byte, version int, timestamp int64) error {
+	// Skip for NoneBackend
+	if ps.backend == schema.NoneBackend || ps.db == nil {
+		return nil
+	}
+
+	// Use backend-specific UPSERT
+	query := ps.getUpsertQuery()
+	_, err := ps.db.Exec(query, key, value, version, timestamp)
+	return err
+}
+
+// getPlaceholder returns the parameter placeholder for the backend.
+func (ps *CacheStoreImpl) getPlaceholder() string {
+	switch ps.backend {
+	case schema.PostgreSQLBackend:
+		return "$1"
+	default: // SQLite and MySQL
+		return "?"
+	}
+}
+
+// getUpsertQuery returns the UPSERT query for the backend.
+func (ps *CacheStoreImpl) getUpsertQuery() string {
+	quotedTableName := quoteTableName(ps.tableName, ps.backend)
+	switch ps.backend {
+	case schema.MySQLBackend:
+		return fmt.Sprintf(`INSERT INTO %s (cache_key, cache_value, cache_version, cache_timestamp) VALUES (?, ?, ?, ?) AS new
+			ON DUPLICATE KEY UPDATE cache_value = new.cache_value, cache_version = new.cache_version, cache_timestamp = new.cache_timestamp`, quotedTableName)
+
+	case schema.PostgreSQLBackend:
+		return fmt.Sprintf(`INSERT INTO %s (cache_key, cache_value, cache_version, cache_timestamp) VALUES ($1, $2, $3, $4)
+			ON CONFLICT (cache_key) DO UPDATE SET cache_value = EXCLUDED.cache_value, cache_version = EXCLUDED.cache_version, cache_timestamp = EXCLUDED.cache_timestamp`, quotedTableName)
+
+	default: // SQLite
+		return fmt.Sprintf(`INSERT OR REPLACE INTO %s (cache_key, cache_value, cache_version, cache_timestamp) VALUES (?, ?, ?, ?)`, quotedTableName)
+	}
+}
+
+// Close closes the underlying DB connection.
+func (ps *CacheStoreImpl) Close() error {
+	if ps.db != nil {
+		return ps.db.Close()
+	}
+	return nil
+}

--- a/internal/iocache/iocache.go
+++ b/internal/iocache/iocache.go
@@ -2,21 +2,16 @@
 package iocache
 
 import (
-	"database/sql"
-	"fmt"
 	"sync"
 
-	_ "github.com/go-sql-driver/mysql" // MySQL driver
 	"github.com/huangsam/hotspot/internal/contract"
-	"github.com/huangsam/hotspot/schema"
-	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver
-	_ "github.com/mattn/go-sqlite3"    // SQLite driver
 )
 
 // CacheStoreManager manages multiple CacheStore instances.
 type CacheStoreManager struct {
 	sync.RWMutex // Protects the store pointers during initialization
 	activity     contract.CacheStore
+	analysis     contract.AnalysisStore
 }
 
 var _ contract.CacheManager = &CacheStoreManager{} // Compile-time check
@@ -28,191 +23,9 @@ func (mgr *CacheStoreManager) GetActivityStore() contract.CacheStore {
 	return mgr.activity
 }
 
-// CacheStoreImpl handles durable storage operations using various database backends.
-type CacheStoreImpl struct {
-	db         *sql.DB
-	tableName  string
-	backend    schema.CacheBackend
-	driverName string
-}
-
-var _ contract.CacheStore = &CacheStoreImpl{} // Compile-time check
-
-// NewCacheStore initializes and returns a new CacheStore based on the backend type.
-func NewCacheStore(tableName string, backend schema.CacheBackend, connStr string) (contract.CacheStore, error) {
-	// Validate table name to prevent SQL injection
-	if err := validateTableName(tableName); err != nil {
-		return nil, err
-	}
-
-	var db *sql.DB
-	var err error
-	var driverName string
-
-	switch backend {
-	case schema.SQLiteBackend:
-		driverName = "sqlite3"
-		dbPath := GetDBFilePath()
-		db, err = sql.Open(driverName, dbPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open SQLite database: %w", err)
-		}
-
-	case schema.MySQLBackend:
-		// connStr should be:
-		// user:password@tcp(host:port)/dbname
-		driverName = "mysql"
-		db, err = sql.Open(driverName, connStr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open MySQL database: %w", err)
-		}
-
-	case schema.PostgreSQLBackend:
-		// connStr should be:
-		// host=localhost port=5432 user=postgres password=mysecretpassword dbname=postgres
-		driverName = "pgx"
-		db, err = sql.Open(driverName, connStr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open PostgreSQL database: %w", err)
-		}
-
-	case schema.NoneBackend:
-		// Return a no-op store for disabled caching
-		return &CacheStoreImpl{
-			db:         nil,
-			tableName:  tableName,
-			backend:    backend,
-			driverName: "",
-		}, nil
-
-	default:
-		return nil, fmt.Errorf("unsupported cache backend: %s", backend)
-	}
-
-	// Ping to verify connection (skip for NoneBackend)
-	if err := db.Ping(); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to ping %s database: %w", backend, err)
-	}
-
-	// Create the table schema
-	query := getCreateTableQuery(tableName, backend)
-	if _, err := db.Exec(query); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to create table %s: %w", tableName, err)
-	}
-
-	return &CacheStoreImpl{
-		db:         db,
-		tableName:  tableName,
-		backend:    backend,
-		driverName: driverName,
-	}, nil
-}
-
-// getCreateTableQuery returns the CREATE TABLE query for the given backend.
-func getCreateTableQuery(tableName string, backend schema.CacheBackend) string {
-	quotedTableName := quoteTableName(tableName, backend)
-	switch backend {
-	case schema.MySQLBackend:
-		return fmt.Sprintf(`
-			CREATE TABLE IF NOT EXISTS %s (
-				cache_key VARCHAR(255) PRIMARY KEY,
-				cache_value BLOB NOT NULL,
-				cache_version INT NOT NULL,
-				cache_timestamp BIGINT NOT NULL
-			);
-		`, quotedTableName)
-
-	case schema.PostgreSQLBackend:
-		return fmt.Sprintf(`
-			CREATE TABLE IF NOT EXISTS %s (
-				cache_key TEXT PRIMARY KEY,
-				cache_value BYTEA NOT NULL,
-				cache_version INTEGER NOT NULL,
-				cache_timestamp BIGINT NOT NULL
-			);
-		`, quotedTableName)
-
-	default: // SQLite
-		return fmt.Sprintf(`
-			CREATE TABLE IF NOT EXISTS %s (
-				cache_key TEXT PRIMARY KEY,
-				cache_value BLOB NOT NULL,
-				cache_version INTEGER NOT NULL,
-				cache_timestamp INTEGER NOT NULL
-			);
-		`, quotedTableName)
-	}
-}
-
-// Get retrieves a value by key from the store.
-func (ps *CacheStoreImpl) Get(key string) ([]byte, int, int64, error) {
-	// Return not found error for NoneBackend
-	if ps.backend == schema.NoneBackend || ps.db == nil {
-		return nil, 0, 0, sql.ErrNoRows
-	}
-
-	var value []byte
-	var version int
-	var ts int64
-
-	// Use backend-specific placeholder
-	quotedTableName := quoteTableName(ps.tableName, ps.backend)
-	placeholder := ps.getPlaceholder()
-	query := fmt.Sprintf(`SELECT cache_value, cache_version, cache_timestamp FROM %s WHERE cache_key = %s`, quotedTableName, placeholder)
-	row := ps.db.QueryRow(query, key)
-
-	if err := row.Scan(&value, &version, &ts); err != nil {
-		return nil, 0, 0, err
-	}
-	return value, version, ts, nil
-}
-
-// Set inserts or replaces a key/value pair in the store.
-func (ps *CacheStoreImpl) Set(key string, value []byte, version int, timestamp int64) error {
-	// Skip for NoneBackend
-	if ps.backend == schema.NoneBackend || ps.db == nil {
-		return nil
-	}
-
-	// Use backend-specific UPSERT
-	query := ps.getUpsertQuery()
-	_, err := ps.db.Exec(query, key, value, version, timestamp)
-	return err
-}
-
-// getPlaceholder returns the parameter placeholder for the backend.
-func (ps *CacheStoreImpl) getPlaceholder() string {
-	switch ps.backend {
-	case schema.PostgreSQLBackend:
-		return "$1"
-	default: // SQLite and MySQL
-		return "?"
-	}
-}
-
-// getUpsertQuery returns the UPSERT query for the backend.
-func (ps *CacheStoreImpl) getUpsertQuery() string {
-	quotedTableName := quoteTableName(ps.tableName, ps.backend)
-	switch ps.backend {
-	case schema.MySQLBackend:
-		return fmt.Sprintf(`INSERT INTO %s (cache_key, cache_value, cache_version, cache_timestamp) VALUES (?, ?, ?, ?) AS new
-			ON DUPLICATE KEY UPDATE cache_value = new.cache_value, cache_version = new.cache_version, cache_timestamp = new.cache_timestamp`, quotedTableName)
-
-	case schema.PostgreSQLBackend:
-		return fmt.Sprintf(`INSERT INTO %s (cache_key, cache_value, cache_version, cache_timestamp) VALUES ($1, $2, $3, $4)
-			ON CONFLICT (cache_key) DO UPDATE SET cache_value = EXCLUDED.cache_value, cache_version = EXCLUDED.cache_version, cache_timestamp = EXCLUDED.cache_timestamp`, quotedTableName)
-
-	default: // SQLite
-		return fmt.Sprintf(`INSERT OR REPLACE INTO %s (cache_key, cache_value, cache_version, cache_timestamp) VALUES (?, ?, ?, ?)`, quotedTableName)
-	}
-}
-
-// Close closes the underlying DB connection.
-func (ps *CacheStoreImpl) Close() error {
-	if ps.db != nil {
-		return ps.db.Close()
-	}
-	return nil
+// GetAnalysisStore returns the analysis AnalysisStore.
+func (mgr *CacheStoreManager) GetAnalysisStore() contract.AnalysisStore {
+	mgr.RLock()
+	defer mgr.RUnlock()
+	return mgr.analysis
 }

--- a/internal/outwriter/output_utils.go
+++ b/internal/outwriter/output_utils.go
@@ -33,9 +33,9 @@ func WriteWithOutputFile(cfg *contract.Config, writer func(io.Writer) error, suc
 
 	if file != os.Stdout {
 		if cfg.UseEmojis {
-			_, _ = fmt.Fprintf(os.Stderr, "💾 %s to %s\n", successMsg, cfg.OutputFile)
+			_, _ = fmt.Fprintf(os.Stdout, "💾 %s to %s\n", successMsg, cfg.OutputFile)
 		} else {
-			_, _ = fmt.Fprintf(os.Stderr, "%s to %s\n", successMsg, cfg.OutputFile)
+			_, _ = fmt.Fprintf(os.Stdout, "%s to %s\n", successMsg, cfg.OutputFile)
 		}
 	}
 	return nil

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -202,3 +202,24 @@ type MetricsModeWithData struct {
 	Weights map[string]float64 `json:"weights"`
 	Formula string             `json:"formula"`
 }
+
+// FileMetrics represents raw git metrics for a single file.
+type FileMetrics struct {
+	AnalysisTime     time.Time
+	TotalCommits     int
+	TotalChurn       int
+	ContributorCount int
+	AgeDays          float64
+	GiniCoefficient  float64
+	FileOwner        string
+}
+
+// FileScores represents final computed scores for a single file.
+type FileScores struct {
+	AnalysisTime    time.Time
+	HotScore        float64 // hot mode score
+	RiskScore       float64 // risk mode score
+	ComplexityScore float64 // complexity mode score
+	StaleScore      float64 // stale mode score
+	ScoreLabel      string  // current mode name
+}


### PR DESCRIPTION
- Implement AnalysisStore interface supporting SQLite, MySQL, and PostgreSQL
- Add three database tables: hotspot_analysis_runs, hotspot_raw_git_metrics, hotspot_final_scores
- Integrate tracking into core analysis pipeline with BeginAnalysis/EndAnalysis lifecycle
- Add --analysis-backend and --analysis-db-connect CLI flags for configuration
- Include comprehensive test coverage and proper error handling
- Tracking is opt-in and non-blocking to preserve existing functionality

Thanks to extensive experimentation and brainstorming in #15