### PR TITLE
Show status for analysis and cache backends

### DIFF
--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -58,6 +58,7 @@ type CacheManager interface {
 type CacheStore interface {
 	Get(key string) ([]byte, int, int64, error)
 	Set(key string, value []byte, version int, timestamp int64) error
+	GetStatus() (schema.CacheStatus, error)
 	Close() error
 }
 
@@ -74,6 +75,9 @@ type AnalysisStore interface {
 
 	// RecordFileScores stores final scores for a file
 	RecordFileScores(analysisID int64, filePath string, scores schema.FileScores) error
+
+	// GetStatus returns status information about the analysis store
+	GetStatus() (schema.AnalysisStatus, error)
 
 	// Close closes the underlying connection
 	Close() error

--- a/internal/iocache/analysis_store.go
+++ b/internal/iocache/analysis_store.go
@@ -542,7 +542,7 @@ func (as *AnalysisStoreImpl) GetStatus() (schema.AnalysisStatus, error) {
 		}
 
 		// Get total files analyzed
-		filesQuery := fmt.Sprintf("SELECT SUM(total_files_analyzed) FROM %s", quoteTableName(analysisRunsTable, as.backend))
+		filesQuery := fmt.Sprintf("SELECT COALESCE(SUM(total_files_analyzed), 0) FROM %s", quoteTableName(analysisRunsTable, as.backend))
 		row = as.db.QueryRow(filesQuery)
 		if err := row.Scan(&status.TotalFilesAnalyzed); err != nil {
 			return status, fmt.Errorf("failed to get total files analyzed: %w", err)

--- a/internal/iocache/analysis_store.go
+++ b/internal/iocache/analysis_store.go
@@ -477,6 +477,94 @@ func (as *AnalysisStoreImpl) Close() error {
 	return nil
 }
 
+// GetStatus returns status information about the analysis store.
+func (as *AnalysisStoreImpl) GetStatus() (schema.AnalysisStatus, error) {
+	status := schema.AnalysisStatus{
+		Backend:    string(as.backend),
+		Connected:  as.db != nil,
+		TableSizes: make(map[string]int64),
+	}
+
+	if as.backend == schema.NoneBackend || as.db == nil {
+		return status, nil
+	}
+
+	// Get total runs
+	runsQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", quoteTableName(analysisRunsTable, as.backend))
+	row := as.db.QueryRow(runsQuery)
+	if err := row.Scan(&status.TotalRuns); err != nil {
+		return status, fmt.Errorf("failed to get total runs: %w", err)
+	}
+
+	if status.TotalRuns > 0 {
+		// Get last run info
+		lastRunQuery := fmt.Sprintf("SELECT analysis_id, start_time FROM %s ORDER BY analysis_id DESC LIMIT 1", quoteTableName(analysisRunsTable, as.backend))
+		row = as.db.QueryRow(lastRunQuery)
+
+		switch as.backend {
+		case schema.SQLiteBackend:
+			var lastRunID int64
+			var lastRunTimeStr string
+			if err := row.Scan(&lastRunID, &lastRunTimeStr); err != nil {
+				return status, fmt.Errorf("failed to get last run info: %w", err)
+			}
+			status.LastRunID = lastRunID
+			lastRunTime, err := time.Parse(time.RFC3339Nano, lastRunTimeStr)
+			if err != nil {
+				return status, fmt.Errorf("failed to parse last run time: %w", err)
+			}
+			status.LastRunTime = lastRunTime
+		default: // MySQL and PostgreSQL store as native datetime
+			if err := row.Scan(&status.LastRunID, &status.LastRunTime); err != nil {
+				return status, fmt.Errorf("failed to get last run info: %w", err)
+			}
+		}
+
+		// Get oldest run time
+		oldestRunQuery := fmt.Sprintf("SELECT start_time FROM %s ORDER BY analysis_id ASC LIMIT 1", quoteTableName(analysisRunsTable, as.backend))
+		row = as.db.QueryRow(oldestRunQuery)
+
+		switch as.backend {
+		case schema.SQLiteBackend:
+			var oldestRunTimeStr string
+			if err := row.Scan(&oldestRunTimeStr); err != nil {
+				return status, fmt.Errorf("failed to get oldest run time: %w", err)
+			}
+			oldestRunTime, err := time.Parse(time.RFC3339Nano, oldestRunTimeStr)
+			if err != nil {
+				return status, fmt.Errorf("failed to parse oldest run time: %w", err)
+			}
+			status.OldestRunTime = oldestRunTime
+		default: // MySQL and PostgreSQL store as native datetime
+			if err := row.Scan(&status.OldestRunTime); err != nil {
+				return status, fmt.Errorf("failed to get oldest run time: %w", err)
+			}
+		}
+
+		// Get total files analyzed
+		filesQuery := fmt.Sprintf("SELECT SUM(total_files_analyzed) FROM %s", quoteTableName(analysisRunsTable, as.backend))
+		row = as.db.QueryRow(filesQuery)
+		if err := row.Scan(&status.TotalFilesAnalyzed); err != nil {
+			return status, fmt.Errorf("failed to get total files analyzed: %w", err)
+		}
+	}
+
+	// Get table sizes
+	tables := []string{analysisRunsTable, rawGitMetricsTable, finalScoresTable}
+	for _, table := range tables {
+		quotedTable := quoteTableName(table, as.backend)
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", quotedTable)
+		row = as.db.QueryRow(countQuery)
+		var count int64
+		if err := row.Scan(&count); err != nil {
+			return status, fmt.Errorf("failed to get count for table %s: %w", table, err)
+		}
+		status.TableSizes[table] = count
+	}
+
+	return status, nil
+}
+
 // formatTime converts a time.Time to the appropriate format for the backend.
 func formatTime(t time.Time, backend schema.CacheBackend) any {
 	switch backend {

--- a/internal/iocache/analysis_store_test.go
+++ b/internal/iocache/analysis_store_test.go
@@ -256,3 +256,111 @@ func TestAnalysisStore_RuntimeCapture(t *testing.T) {
 		assert.LessOrEqual(t, storedDurationMs, int64(5100))
 	})
 }
+
+func TestAnalysisStore_GetStatus(t *testing.T) {
+	t.Run("SQLite backend with data", func(t *testing.T) {
+		store, err := NewAnalysisStore(schema.SQLiteBackend, ":memory:")
+		require.NoError(t, err)
+		require.NotNil(t, store)
+		defer func() { _ = store.Close() }()
+
+		// Create some analysis runs
+		startTime := time.Now()
+		runs := []map[string]any{
+			{"mode": "hot", "lookback": "30d"},
+			{"mode": "risk", "lookback": "60d"},
+			{"mode": "complexity", "lookback": "90d"},
+		}
+
+		var analysisIDs []int64
+		for _, config := range runs {
+			id, err := store.BeginAnalysis(startTime, config)
+			require.NoError(t, err)
+			analysisIDs = append(analysisIDs, id)
+
+			// Add some metrics
+			metrics := schema.FileMetrics{
+				AnalysisTime:     startTime,
+				TotalCommits:     100,
+				TotalChurn:       500,
+				ContributorCount: 5,
+				AgeDays:          365.0,
+				GiniCoefficient:  0.5,
+				FileOwner:        "owner",
+			}
+			err = store.RecordFileMetrics(id, "test.go", metrics)
+			assert.NoError(t, err)
+
+			scores := schema.FileScores{
+				AnalysisTime:    startTime,
+				HotScore:        75.5,
+				RiskScore:       80.2,
+				ComplexityScore: 65.3,
+				StaleScore:      70.1,
+				ScoreLabel:      "hot",
+			}
+			err = store.RecordFileScores(id, "test.go", scores)
+			assert.NoError(t, err)
+
+			err = store.EndAnalysis(id, startTime.Add(time.Minute), 1)
+			assert.NoError(t, err)
+		}
+
+		// Get status
+		status, err := store.GetStatus()
+		assert.NoError(t, err, "GetStatus should not fail")
+
+		assert.Len(t, analysisIDs, 3, "Should have collected 3 analysis IDs")
+		assert.Equal(t, "sqlite", status.Backend, "Backend should be sqlite")
+		assert.True(t, status.Connected, "Should be connected")
+		assert.Equal(t, 3, status.TotalRuns, "Total runs should be 3")
+		assert.Greater(t, status.LastRunID, int64(0), "Last run ID should be set")
+		assert.True(t, !status.LastRunTime.IsZero(), "Last run time should not be zero")
+		assert.True(t, status.OldestRunTime.Equal(startTime) || !status.OldestRunTime.IsZero(), "Oldest run time should be set")
+		assert.Equal(t, 3, status.TotalFilesAnalyzed, "Total files analyzed should be 3")
+		assert.Contains(t, status.TableSizes, "hotspot_analysis_runs", "Should have analysis_runs table size")
+		assert.Contains(t, status.TableSizes, "hotspot_raw_git_metrics", "Should have raw_git_metrics table size")
+		assert.Contains(t, status.TableSizes, "hotspot_final_scores", "Should have final_scores table size")
+	})
+
+	t.Run("SQLite backend empty", func(t *testing.T) {
+		store, err := NewAnalysisStore(schema.SQLiteBackend, ":memory:")
+		require.NoError(t, err)
+		require.NotNil(t, store)
+		defer func() { _ = store.Close() }()
+
+		// Get status without data
+		status, err := store.GetStatus()
+		assert.NoError(t, err, "GetStatus should not fail")
+
+		assert.Equal(t, "sqlite", status.Backend, "Backend should be sqlite")
+		assert.True(t, status.Connected, "Should be connected")
+		assert.Equal(t, 0, status.TotalRuns, "Total runs should be 0")
+		assert.Equal(t, int64(0), status.LastRunID, "Last run ID should be 0")
+		assert.True(t, status.LastRunTime.IsZero(), "Last run time should be zero")
+		assert.True(t, status.OldestRunTime.IsZero(), "Oldest run time should be zero")
+		assert.Equal(t, 0, status.TotalFilesAnalyzed, "Total files analyzed should be 0")
+		assert.Contains(t, status.TableSizes, "hotspot_analysis_runs", "Should have analysis_runs table size")
+		assert.Contains(t, status.TableSizes, "hotspot_raw_git_metrics", "Should have raw_git_metrics table size")
+		assert.Contains(t, status.TableSizes, "hotspot_final_scores", "Should have final_scores table size")
+	})
+
+	t.Run("None backend", func(t *testing.T) {
+		store, err := NewAnalysisStore(schema.NoneBackend, "")
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		// Get status
+		status, err := store.GetStatus()
+		assert.NoError(t, err, "GetStatus should not fail")
+
+		assert.Equal(t, "none", status.Backend, "Backend should be none")
+		assert.False(t, status.Connected, "Should not be connected")
+		assert.Equal(t, 0, status.TotalRuns, "Total runs should be 0")
+		assert.Equal(t, int64(0), status.LastRunID, "Last run ID should be 0")
+		assert.True(t, status.LastRunTime.IsZero(), "Last run time should be zero")
+		assert.True(t, status.OldestRunTime.IsZero(), "Oldest run time should be zero")
+		assert.Equal(t, 0, status.TotalFilesAnalyzed, "Total files analyzed should be 0")
+		assert.Empty(t, status.TableSizes, "Table sizes should be empty")
+	})
+}

--- a/internal/iocache/cache_mock.go
+++ b/internal/iocache/cache_mock.go
@@ -54,6 +54,12 @@ func (m *MockCacheStore) Close() error {
 	return args.Error(0)
 }
 
+// GetStatus implements the CacheStore interface.
+func (m *MockCacheStore) GetStatus() (schema.CacheStatus, error) {
+	args := m.Called()
+	return args.Get(0).(schema.CacheStatus), args.Error(1)
+}
+
 // MockAnalysisStore is a mock implementation of AnalysisStore for testing.
 type MockAnalysisStore struct {
 	mock.Mock
@@ -89,4 +95,10 @@ func (m *MockAnalysisStore) RecordFileScores(analysisID int64, filePath string, 
 func (m *MockAnalysisStore) Close() error {
 	args := m.Called()
 	return args.Error(0)
+}
+
+// GetStatus implements the AnalysisStore interface.
+func (m *MockAnalysisStore) GetStatus() (schema.AnalysisStatus, error) {
+	args := m.Called()
+	return args.Get(0).(schema.AnalysisStatus), args.Error(1)
 }

--- a/internal/iocache/cache_store.go
+++ b/internal/iocache/cache_store.go
@@ -4,6 +4,8 @@ package iocache
 import (
 	"database/sql"
 	"fmt"
+	"strings"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql" // MySQL driver
 	"github.com/huangsam/hotspot/internal/contract"
@@ -18,6 +20,7 @@ type CacheStoreImpl struct {
 	tableName  string
 	backend    schema.CacheBackend
 	driverName string
+	connStr    string
 }
 
 var _ contract.CacheStore = &CacheStoreImpl{} // Compile-time check
@@ -72,6 +75,7 @@ func NewCacheStore(tableName string, backend schema.CacheBackend, connStr string
 			tableName:  tableName,
 			backend:    backend,
 			driverName: "",
+			connStr:    connStr,
 		}, nil
 
 	default:
@@ -96,6 +100,7 @@ func NewCacheStore(tableName string, backend schema.CacheBackend, connStr string
 		tableName:  tableName,
 		backend:    backend,
 		driverName: driverName,
+		connStr:    connStr,
 	}, nil
 }
 
@@ -204,4 +209,89 @@ func (ps *CacheStoreImpl) Close() error {
 		return ps.db.Close()
 	}
 	return nil
+}
+
+// GetStatus returns status information about the cache store.
+func (ps *CacheStoreImpl) GetStatus() (schema.CacheStatus, error) {
+	status := schema.CacheStatus{
+		Backend:   string(ps.backend),
+		Connected: ps.db != nil,
+	}
+
+	if ps.backend == schema.NoneBackend || ps.db == nil {
+		return status, nil
+	}
+
+	quotedTableName := quoteTableName(ps.tableName, ps.backend)
+
+	// Get total entries
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", quotedTableName)
+	row := ps.db.QueryRow(countQuery)
+	if err := row.Scan(&status.TotalEntries); err != nil {
+		return status, fmt.Errorf("failed to get total entries: %w", err)
+	}
+
+	if status.TotalEntries == 0 {
+		return status, nil
+	}
+
+	// Get last entry time
+	lastQuery := fmt.Sprintf("SELECT MAX(cache_timestamp) FROM %s", quotedTableName)
+	row = ps.db.QueryRow(lastQuery)
+	var lastTs int64
+	if err := row.Scan(&lastTs); err != nil {
+		return status, fmt.Errorf("failed to get last entry time: %w", err)
+	}
+	status.LastEntryTime = time.Unix(lastTs, 0)
+
+	// Get oldest entry time
+	oldestQuery := fmt.Sprintf("SELECT MIN(cache_timestamp) FROM %s", quotedTableName)
+	row = ps.db.QueryRow(oldestQuery)
+	var oldestTs int64
+	if err := row.Scan(&oldestTs); err != nil {
+		return status, fmt.Errorf("failed to get oldest entry time: %w", err)
+	}
+	status.OldestEntryTime = time.Unix(oldestTs, 0)
+
+	// Estimate table size (approximate)
+	// For SQLite, use page_count * page_size
+	// For others, estimate based on row count (rough approximation)
+	if ps.backend == schema.SQLiteBackend {
+		sizeQuery := "SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()"
+		row = ps.db.QueryRow(sizeQuery)
+		if err := row.Scan(&status.TableSizeBytes); err != nil {
+			// If pragma fails, skip size
+			status.TableSizeBytes = 0
+		}
+	} else {
+		// For MySQL/PostgreSQL, use database-specific size queries
+		var sizeQuery string
+		switch ps.backend {
+		case schema.MySQLBackend:
+			// Extract database name from connection string
+			// Format: user:pass@tcp(host:port)/db?params
+			parts := strings.Split(ps.connStr, "/")
+			if len(parts) >= 2 {
+				dbName := strings.Split(parts[1], "?")[0] // Remove query params
+				sizeQuery = fmt.Sprintf("SELECT data_length + index_length FROM information_schema.tables WHERE table_schema = '%s' AND table_name = '%s'", dbName, ps.tableName)
+				row = ps.db.QueryRow(sizeQuery)
+				if err := row.Scan(&status.TableSizeBytes); err != nil {
+					status.TableSizeBytes = int64(status.TotalEntries) * 1000 // Fallback rough estimate
+				}
+			} else {
+				status.TableSizeBytes = int64(status.TotalEntries) * 1000 // Rough estimate
+			}
+		case schema.PostgreSQLBackend:
+			// Use pg_total_relation_size for PostgreSQL
+			sizeQuery = fmt.Sprintf("SELECT pg_total_relation_size('%s')", ps.tableName)
+			row = ps.db.QueryRow(sizeQuery)
+			if err := row.Scan(&status.TableSizeBytes); err != nil {
+				status.TableSizeBytes = int64(status.TotalEntries) * 1000 // Fallback rough estimate
+			}
+		default:
+			status.TableSizeBytes = int64(status.TotalEntries) * 1000 // Rough estimate
+		}
+	}
+
+	return status, nil
 }

--- a/internal/iocache/cache_store.go
+++ b/internal/iocache/cache_store.go
@@ -273,8 +273,8 @@ func (ps *CacheStoreImpl) GetStatus() (schema.CacheStatus, error) {
 			parts := strings.Split(ps.connStr, "/")
 			if len(parts) >= 2 {
 				dbName := strings.Split(parts[1], "?")[0] // Remove query params
-				sizeQuery = fmt.Sprintf("SELECT data_length + index_length FROM information_schema.tables WHERE table_schema = '%s' AND table_name = '%s'", dbName, ps.tableName)
-				row = ps.db.QueryRow(sizeQuery)
+				sizeQuery = "SELECT data_length + index_length FROM information_schema.tables WHERE table_schema = ? AND table_name = ?"
+				row = ps.db.QueryRow(sizeQuery, dbName, ps.tableName)
 				if err := row.Scan(&status.TableSizeBytes); err != nil {
 					status.TableSizeBytes = int64(status.TotalEntries) * 1000 // Fallback rough estimate
 				}
@@ -283,8 +283,8 @@ func (ps *CacheStoreImpl) GetStatus() (schema.CacheStatus, error) {
 			}
 		case schema.PostgreSQLBackend:
 			// Use pg_total_relation_size for PostgreSQL
-			sizeQuery = fmt.Sprintf("SELECT pg_total_relation_size('%s')", ps.tableName)
-			row = ps.db.QueryRow(sizeQuery)
+			sizeQuery = "SELECT pg_total_relation_size($1)"
+			row = ps.db.QueryRow(sizeQuery, ps.tableName)
 			if err := row.Scan(&status.TableSizeBytes); err != nil {
 				status.TableSizeBytes = int64(status.TotalEntries) * 1000 // Fallback rough estimate
 			}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -223,3 +223,25 @@ type FileScores struct {
 	StaleScore      float64 // stale mode score
 	ScoreLabel      string  // current mode name
 }
+
+// CacheStatus represents the status of the cache store.
+type CacheStatus struct {
+	Backend         string    `json:"backend"`
+	Connected       bool      `json:"connected"`
+	TotalEntries    int       `json:"total_entries"`
+	LastEntryTime   time.Time `json:"last_entry_time"`
+	OldestEntryTime time.Time `json:"oldest_entry_time"`
+	TableSizeBytes  int64     `json:"table_size_bytes"`
+}
+
+// AnalysisStatus represents the status of the analysis store.
+type AnalysisStatus struct {
+	Backend            string           `json:"backend"`
+	Connected          bool             `json:"connected"`
+	TotalRuns          int              `json:"total_runs"`
+	LastRunID          int64            `json:"last_run_id"`
+	LastRunTime        time.Time        `json:"last_run_time"`
+	OldestRunTime      time.Time        `json:"oldest_run_time"`
+	TotalFilesAnalyzed int              `json:"total_files_analyzed"`
+	TableSizes         map[string]int64 `json:"table_sizes"`
+}


### PR DESCRIPTION
Since we now have so much functionality built into the analysis and cache backends, it is now worthwhile to add status sub-commands so that people can investigate the DB entries more carefully to see whether storage / records / etc. are an issue. It also helps people when they want to submit GitHub issues to the repository.