### PR TITLE
Implement composite modes for CLI and MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [1.22.0] - 2026-05-04
+
+### Added
+- Three composite scoring modes: `active_owners`, `refactor_now`, `legacy_debt`.
+- Composite modes blend two base scoring algorithms for targeted risk analysis.
+- active_owners (hot+risk): volatile files with concentrated ownership.
+- refactor_now (complexity+roi): refactoring targets by highest ROI.
+- legacy_debt (complexity+risk): fragile legacy systems needing expert review.
+- Dynamic composite reasoning labels via base mode concatenation.
+- Full CLI and MCP support for composite mode analysis.
+
 ## [1.21.0] - 2026-04-27
 
 ### Added

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -26,12 +26,34 @@ The core power of Hotspot lies in its `--mode` flag, which selects the ranking a
 
 `hotspot files --mode risk --owner`
 
+#### Base Modes
 | Mode | Focus | Description |
 |------|-------|-------------|
 | **hot** | Activity hotspots | Identify files and subsystems with the most activity. |
 | **risk** | Knowledge risk | Find areas with unequal ownership and knowledge decay. |
 | **complexity** | Technical debt | Triage files with high churn, large size, and high complexity. |
 | **roi** | Refactoring ROI | Prioritize refactoring targets that offer the highest technical return. |
+
+#### Composite Modes (v1.22.0+)
+Composite modes blend two base scoring modes to surface nuanced problem types:
+
+| Mode | Blend | Use Case |
+|------|-------|----------|
+| **active_owners** | Hot (50%) + Risk (50%) | High activity + concentrated ownership. Prioritize knowledge transfer for actively developed siloed code. |
+| **refactor_now** | Complexity (60%) + ROI (40%) | Large, churning legacy code = highest refactoring ROI. Prioritize these for sprint planning. |
+| **legacy_debt** | Complexity (70%) + Risk (30%) | Old, complex, siloed code = high blast radius if touched. Requires expert review. |
+
+**Examples:**
+```bash
+# Find volatile files with concentrated ownership (highest urgency for knowledge transfer)
+hotspot files --mode active_owners --owner --limit 20
+
+# Prioritize refactoring targets by highest technical ROI
+hotspot files --mode refactor_now --output describe
+
+# Identify fragile legacy systems that need expert review
+hotspot files --mode legacy_debt --detail
+```
 
 ### 3. Risk Comparison & Delta Tracking
 Measure the change in metrics between two different points in history.

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -15,7 +15,7 @@ var checkCmd = &cobra.Command{
 Designed specifically for CI/CD integration - fails with non-zero exit code when files
 exceed acceptable risk levels. Analyzes only the changed files, making it fast and focused.
 
-Default thresholds: 50.0 for all modes (hot, risk, complexity, roi)
+Default thresholds: 50.0 for all modes (hot, risk, complexity, roi, active_owners, refactor_now, legacy_debt)
 
 Use cases:
 - Pull request gates - block merges with high-risk changes
@@ -28,7 +28,7 @@ Examples:
   hotspot check --base-ref origin/main --target-ref HEAD
 
   # Custom thresholds per mode
-  hotspot check --base-ref main --target-ref feature --thresholds-override "hot:75,risk:60,complexity:80"
+  hotspot check --base-ref main --target-ref feature --thresholds-override "hot:75,risk:60,complexity:80,active_owners:70"
 
   # Check release candidate
   hotspot check --base-ref v1.0.0 --target-ref v1.1.0-rc1

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -45,7 +45,7 @@ func init() {
 	rootCmd.PersistentFlags().String("exclude", schema.DefaultExclude, "Comma-separated list of path prefixes or patterns to ignore")
 	rootCmd.PersistentFlags().StringP("filter", "f", "", "Filter targets by path prefix")
 	rootCmd.PersistentFlags().IntP("limit", "l", 0, "Number of results to display")
-	rootCmd.PersistentFlags().String("mode", "", "Scoring mode: hot or risk or complexity or roi")
+	rootCmd.PersistentFlags().String("mode", "", "Scoring mode: hot, risk, complexity, roi, active_owners, refactor_now, legacy_debt")
 	rootCmd.PersistentFlags().String("output", "", "Output format: text or csv or json or parquet or markdown or describe or heatmap")
 	rootCmd.PersistentFlags().String("output-file", "", "Optional path to write output to")
 	rootCmd.PersistentFlags().Bool("owner", false, "Print per-target owner")
@@ -86,7 +86,7 @@ func init() {
 	}
 
 	// Bind all flags of checkCmd to Viper
-	checkCmd.Flags().String("thresholds-override", "", "Risk thresholds for CI/CD gating (format: 'hot:50,risk:50,complexity:50,roi:50')")
+	checkCmd.Flags().String("thresholds-override", "", "Risk thresholds for CI/CD gating (format: 'hot:50,risk:50,complexity:50,roi:50,active_owners:50,refactor_now:50,legacy_debt:50')")
 	if err := viper.BindPFlags(checkCmd.Flags()); err != nil {
 		logger.Fatal("Error binding check flags", err)
 	}

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -9,7 +9,7 @@ import (
 // filesCmd performs file-level hotspot analysis.
 var filesCmd = &cobra.Command{
 	Use:   "files [repo-path]",
-	Short: "Rank files by activity, risk, complexity, or refactoring ROI",
+	Short: "Rank files by activity, risk, complexity, refactoring ROI, or composite signals",
 	Long: `Perform deep Git analysis and rank individual files by risk score.
 
 Analyzes the entire history of each file to compute risk metrics, helping you:
@@ -18,8 +18,18 @@ Analyzes the entire history of each file to compute risk metrics, helping you:
 - Spot files with uneven ownership and knowledge silos
 - Locate large, complex files that are difficult to maintain
 
-Scores files based on your selected mode (hot, risk, complexity, roi),
-ranking them from highest to lowest risk.
+Scores files based on your selected mode:
+
+Base Modes:
+- hot: High recent activity and volatility (activity hotspots)
+- risk: Few contributors or concentrated ownership (knowledge risk)
+- complexity: Large, old, volatile files (technical debt)
+- roi: High churn on complex files (refactoring priority)
+
+Composite Modes (blend multiple base modes):
+- active_owners: 50% hot + 50% risk (volatile + siloed code)
+- refactor_now: 60% complexity + 40% roi (high ROI targets)
+- legacy_debt: 70% complexity + 30% risk (fragile + under-maintained)
 
 Examples:
   # Find the most active/volatile files
@@ -33,6 +43,9 @@ Examples:
 
   # Prioritize refactoring targets by ROI
   hotspot files --mode roi
+
+  # Find files that are volatile AND have concentrated ownership
+  hotspot files --mode active_owners --owner
 
   # Include detailed metrics and component breakdown
   hotspot files --detail --explain --owner

--- a/core/agg/agg.go
+++ b/core/agg/agg.go
@@ -364,6 +364,12 @@ func AggregateAndScoreFolders(gitSettings config.GitSettings, scoringSettings co
 				Path: folderPath,
 				Mode: scoringMode,
 			}
+			// Set ModeType based on whether the mode is composite or base
+			if schema.IsCompositeMode(scoringMode) {
+				folderResults[folderPath].ModeType = "composite"
+			} else {
+				folderResults[folderPath].ModeType = "base"
+			}
 		}
 
 		// 2. Aggregate simple metrics and score components

--- a/core/algo/score.go
+++ b/core/algo/score.go
@@ -270,3 +270,102 @@ func isConfigurationFile(ext string) bool {
 		"lock", "sum", "csv", "tsv", "md", "txt", "tfstate",
 	}, ext)
 }
+
+// ComputeCompositeScore blends base mode scores to produce a composite score.
+// It weights the base mode scores according to the composite's blend weights and
+// returns both the blended score and blended breakdown without mutating the input.
+//
+// Parameters:
+//   - file: FileResult with all 4 base mode scores already computed (in AllScores)
+//   - composite: CompositeConfig specifying which modes to blend and their weights
+//
+// Returns: The blended composite score [0-100] and blended breakdown map.
+func ComputeCompositeScore(file *schema.FileResult, composite *schema.CompositeConfig) (float64, map[schema.BreakdownKey]float64) {
+	if file == nil || composite == nil || len(composite.BaseModes) < 2 {
+		return 0.0, map[schema.BreakdownKey]float64{}
+	}
+
+	// Ensure AllScores is populated
+	if len(file.AllScores) == 0 {
+		return 0.0, map[schema.BreakdownKey]float64{}
+	}
+
+	// Resolve and normalize blend weights; fallback to uniform if invalid/incomplete.
+	weights := resolveCompositeWeights(composite)
+
+	// Blend score and breakdowns.
+	var blended float64
+	blendedBreakdown := make(map[schema.BreakdownKey]float64)
+	for _, mode := range composite.BaseModes {
+		score, ok := file.AllScores[mode]
+		if !ok {
+			return 0.0, map[schema.BreakdownKey]float64{}
+		}
+		weight := weights[mode]
+		blended += score * weight
+
+		if breakdown, ok := file.AllBreakdowns[mode]; ok {
+			for key, val := range breakdown {
+				blendedBreakdown[key] += val * weight
+			}
+		}
+	}
+
+	blended = math.Min(math.Max(blended, 0), 100)
+	return blended, blendedBreakdown
+}
+
+func resolveCompositeWeights(composite *schema.CompositeConfig) map[schema.ScoringMode]float64 {
+	if composite == nil || len(composite.BaseModes) == 0 {
+		return map[schema.ScoringMode]float64{}
+	}
+	weights := make(map[schema.ScoringMode]float64, len(composite.BaseModes))
+
+	var sum float64
+	valid := true
+	for _, mode := range composite.BaseModes {
+		w, ok := composite.BlendWeights[mode]
+		if !ok || w <= 0 || math.IsNaN(w) || math.IsInf(w, 0) {
+			valid = false
+			break
+		}
+		weights[mode] = w
+		sum += w
+	}
+
+	if !valid || sum <= 0 {
+		uniform := 1.0 / float64(len(composite.BaseModes))
+		for _, mode := range composite.BaseModes {
+			weights[mode] = uniform
+		}
+		return weights
+	}
+
+	for mode, w := range weights {
+		weights[mode] = w / sum
+	}
+
+	return weights
+}
+
+// GenerateCompositeReasoning combines reasoning from each configured base mode.
+func GenerateCompositeReasoning(file *schema.FileResult, composite *schema.CompositeConfig) []string {
+	if composite == nil || file == nil || len(composite.BaseModes) < 2 {
+		return []string{}
+	}
+
+	if len(file.AllReasoning) == 0 {
+		return []string{}
+	}
+
+	var results []string
+
+	// Collect reasoning from each base mode
+	for _, baseMode := range composite.BaseModes {
+		if reasoning, ok := file.AllReasoning[baseMode]; ok {
+			results = append(results, reasoning...)
+		}
+	}
+
+	return results
+}

--- a/core/algo/score_test.go
+++ b/core/algo/score_test.go
@@ -302,6 +302,119 @@ func TestComputeScoreInvalidCustomWeights(t *testing.T) {
 	assert.True(t, score >= 0 && score <= 100, "Score with empty custom weights should be valid")
 }
 
+func TestComputeCompositeScore_BlendsWithoutMutatingInput(t *testing.T) {
+	file := &schema.FileResult{
+		AllScores: map[schema.ScoringMode]float64{
+			schema.HotMode:  80,
+			schema.RiskMode: 40,
+		},
+		AllBreakdowns: map[schema.ScoringMode]map[schema.BreakdownKey]float64{
+			schema.HotMode: {
+				schema.BreakdownChurn: 60,
+				schema.BreakdownAge:   20,
+			},
+			schema.RiskMode: {
+				schema.BreakdownGini:       50,
+				schema.BreakdownInvContrib: 30,
+			},
+		},
+		ModeBreakdown: map[schema.BreakdownKey]float64{
+			schema.BreakdownSize: 99,
+		},
+	}
+	originalModeBreakdown := maps.Clone(file.ModeBreakdown)
+
+	composite := &schema.CompositeConfig{
+		BaseModes: []schema.ScoringMode{schema.HotMode, schema.RiskMode},
+		BlendWeights: map[schema.ScoringMode]float64{
+			schema.HotMode:  0.75,
+			schema.RiskMode: 0.25,
+		},
+	}
+
+	score, breakdown := ComputeCompositeScore(file, composite)
+	assert.InDelta(t, 70.0, score, 1e-9)
+	assert.InDelta(t, 45.0, breakdown[schema.BreakdownChurn], 1e-9)
+	assert.InDelta(t, 15.0, breakdown[schema.BreakdownAge], 1e-9)
+	assert.InDelta(t, 12.5, breakdown[schema.BreakdownGini], 1e-9)
+	assert.InDelta(t, 7.5, breakdown[schema.BreakdownInvContrib], 1e-9)
+
+	assert.Equal(t, originalModeBreakdown, file.ModeBreakdown)
+}
+
+func TestComputeCompositeScore_WeightValidationAndClamping(t *testing.T) {
+	t.Run("missing weight falls back to uniform weights", func(t *testing.T) {
+		file := &schema.FileResult{
+			AllScores: map[schema.ScoringMode]float64{
+				schema.HotMode:  100,
+				schema.RiskMode: 20,
+			},
+		}
+		composite := &schema.CompositeConfig{
+			BaseModes: []schema.ScoringMode{schema.HotMode, schema.RiskMode},
+			BlendWeights: map[schema.ScoringMode]float64{
+				schema.HotMode: 0.8,
+			},
+		}
+
+		score, _ := ComputeCompositeScore(file, composite)
+		assert.InDelta(t, 60.0, score, 1e-9)
+	})
+
+	t.Run("weights are normalized when sum is not one", func(t *testing.T) {
+		file := &schema.FileResult{
+			AllScores: map[schema.ScoringMode]float64{
+				schema.ComplexityMode: 90,
+				schema.ROIMode:        30,
+			},
+		}
+		composite := &schema.CompositeConfig{
+			BaseModes: []schema.ScoringMode{schema.ComplexityMode, schema.ROIMode},
+			BlendWeights: map[schema.ScoringMode]float64{
+				schema.ComplexityMode: 2,
+				schema.ROIMode:        1,
+			},
+		}
+
+		score, _ := ComputeCompositeScore(file, composite)
+		assert.InDelta(t, 70.0, score, 1e-9)
+	})
+
+	t.Run("composite score is clamped to 100", func(t *testing.T) {
+		file := &schema.FileResult{
+			AllScores: map[schema.ScoringMode]float64{
+				schema.HotMode:  180,
+				schema.RiskMode: 150,
+			},
+		}
+		composite := &schema.CompositeConfig{
+			BaseModes: []schema.ScoringMode{schema.HotMode, schema.RiskMode},
+			BlendWeights: map[schema.ScoringMode]float64{
+				schema.HotMode:  0.5,
+				schema.RiskMode: 0.5,
+			},
+		}
+
+		score, _ := ComputeCompositeScore(file, composite)
+		assert.Equal(t, 100.0, score)
+	})
+}
+
+func TestGenerateCompositeReasoning_ComposesBaseModeReasoning(t *testing.T) {
+	file := &schema.FileResult{
+		AllReasoning: map[schema.ScoringMode][]string{
+			schema.HotMode:  {"Hot reason 1", "Hot reason 2"},
+			schema.RiskMode: {"Risk reason"},
+		},
+	}
+	composite := &schema.CompositeConfig{
+		BaseModes: []schema.ScoringMode{schema.HotMode, schema.RiskMode},
+	}
+
+	reasoning := GenerateCompositeReasoning(file, composite)
+	assert.Equal(t, []string{"Hot reason 1", "Hot reason 2", "Risk reason"}, reasoning)
+}
+
 // FuzzComputeScore fuzzes the ComputeScore function with random FileResult inputs.
 func FuzzComputeScore(f *testing.F) {
 	seeds := []struct {

--- a/core/builder_check.go
+++ b/core/builder_check.go
@@ -177,6 +177,7 @@ func (b *CheckResultBuilder) ComputeMetrics() *CheckResultBuilder {
 					Mode:      mode,
 					Score:     score,
 					Threshold: threshold,
+					Reasoning: file.AllReasoning[mode],
 				})
 			}
 		}

--- a/core/builder_check_test.go
+++ b/core/builder_check_test.go
@@ -145,6 +145,9 @@ func TestCheckResultBuilder_ComputeMetrics(t *testing.T) {
 				schema.RiskMode:       40.0,
 				schema.ComplexityMode: 30.0,
 			},
+			AllReasoning: map[schema.ScoringMode][]string{
+				schema.HotMode: {"High Churn"},
+			},
 			Owners: []string{"alice"},
 		},
 		{
@@ -153,6 +156,9 @@ func TestCheckResultBuilder_ComputeMetrics(t *testing.T) {
 				schema.HotMode:        50.0,
 				schema.RiskMode:       70.0,
 				schema.ComplexityMode: 25.0,
+			},
+			AllReasoning: map[schema.ScoringMode][]string{
+				schema.RiskMode: {"Ownership concentration"},
 			},
 			Owners: []string{"bob"},
 		},
@@ -201,6 +207,7 @@ func TestCheckResultBuilder_ComputeMetrics(t *testing.T) {
 			if actual.Path == expected.Path && actual.Mode == expected.Mode {
 				assert.Equal(t, expected.Score, actual.Score)
 				assert.Equal(t, expected.Threshold, actual.Threshold)
+				assert.NotEmpty(t, actual.Reasoning)
 				found = true
 				break
 			}

--- a/core/builder_file.go
+++ b/core/builder_file.go
@@ -248,35 +248,58 @@ func (b *FileResultBuilder) CalculateOwner() *FileResultBuilder {
 
 // CalculateScore computes the final composite score.
 func (b *FileResultBuilder) CalculateScore() *FileResultBuilder {
-	// Compute score for current mode
 	mode := b.scoringSettings.GetMode()
-	weights := b.scoringSettings.GetComputedWeights()[mode]
 	thresholdLow := b.scoringSettings.GetRecencyThresholdLow()
 	thresholdHigh := b.scoringSettings.GetRecencyThresholdHigh()
-	b.result.ModeScore = algo.ComputeScore(b.result, mode, weights, thresholdLow, thresholdHigh)
 
-	// Compute scores and breakdowns for all modes
+	// Compute scores and breakdowns for all base modes first
 	b.result.AllScores = make(map[schema.ScoringMode]float64)
 	b.result.AllBreakdowns = make(map[schema.ScoringMode]map[schema.BreakdownKey]float64)
+	b.result.AllReasoning = make(map[schema.ScoringMode][]string)
 
 	computedWeights := b.scoringSettings.GetComputedWeights()
 	for _, m := range []schema.ScoringMode{schema.HotMode, schema.RiskMode, schema.ComplexityMode, schema.ROIMode} {
-		if m == mode {
-			// Already computed
-			b.result.AllScores[m] = b.result.ModeScore
-			b.result.AllBreakdowns[m] = make(map[schema.BreakdownKey]float64, len(b.result.ModeBreakdown))
-			maps.Copy(b.result.AllBreakdowns[m], b.result.ModeBreakdown)
-		} else {
-			mCopy := *b.result // Shallow copy of top-level fields
-			// Crucially re-initialize the breakdown map to avoid stomping on the original
-			mCopy.ModeBreakdown = make(map[schema.BreakdownKey]float64, 8)
-			mCopy.Mode = m
-			score := algo.ComputeScore(&mCopy, m, computedWeights[m], thresholdLow, thresholdHigh)
-			b.result.AllScores[m] = score
-			b.result.AllBreakdowns[m] = mCopy.ModeBreakdown
+		mCopy := *b.result // Shallow copy of top-level fields
+		// Crucially re-initialize the breakdown map to avoid stomping on the original
+		mCopy.ModeBreakdown = make(map[schema.BreakdownKey]float64, 8)
+		mCopy.Mode = m
+		score := algo.ComputeScore(&mCopy, m, computedWeights[m], thresholdLow, thresholdHigh)
+		b.result.AllScores[m] = score
+		b.result.AllBreakdowns[m] = mCopy.ModeBreakdown
+		b.result.AllReasoning[m] = mCopy.Reasoning
+		if m == schema.HotMode {
+			b.result.RecencySignal = mCopy.RecencySignal
+			b.result.RecencyThresholdLow = mCopy.RecencyThresholdLow
+			b.result.RecencyThresholdHigh = mCopy.RecencyThresholdHigh
 		}
 	}
 
+	// Compute scores and reasoning for all composite modes
+	for _, m := range []schema.ScoringMode{schema.ActiveOwnersMode, schema.RefactorNowMode, schema.LegacyDebtMode} {
+		compositeConfig := schema.GetCompositeConfig(m)
+		if compositeConfig != nil {
+			score, breakdown := algo.ComputeCompositeScore(b.result, compositeConfig)
+			b.result.AllScores[m] = score
+			b.result.AllBreakdowns[m] = breakdown
+			b.result.AllReasoning[m] = algo.GenerateCompositeReasoning(b.result, compositeConfig)
+		}
+	}
+
+	// Now set the active mode score, breakdown, and reasoning.
+	b.result.ModeScore = b.result.AllScores[mode]
+	if breakdown, ok := b.result.AllBreakdowns[mode]; ok {
+		b.result.ModeBreakdown = breakdown
+	} else {
+		b.result.ModeBreakdown = map[schema.BreakdownKey]float64{}
+	}
+	b.result.Reasoning = b.result.AllReasoning[mode]
+
+	b.result.Mode = mode
+	if schema.IsCompositeMode(mode) {
+		b.result.ModeType = "composite"
+	} else {
+		b.result.ModeType = "base"
+	}
 	return b
 }
 

--- a/core/builder_file_test.go
+++ b/core/builder_file_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -115,4 +117,64 @@ func TestFileResultBuilder_ZeroFirstCommit(t *testing.T) {
 
 	fileResult := builder.Build()
 	assert.Equal(t, schema.Metric(0), fileResult.AgeDays)
+}
+
+func TestFileResultBuilder_CompositeModeUsesSelectedBreakdown(t *testing.T) {
+	ctx := context.Background()
+	const (
+		aliceCommits = schema.Metric(100)
+		bobCommits   = schema.Metric(15)
+		carolCommits = schema.Metric(5)
+	)
+
+	repoPath := t.TempDir()
+	err := os.WriteFile(filepath.Join(repoPath, "critical.go"), []byte("package main\n\nfunc x() {}\n"), 0o644)
+	assert.NoError(t, err)
+
+	cfg := &config.Config{
+		Git: config.GitConfig{
+			RepoPath: repoPath,
+		},
+		Scoring: config.ScoringConfig{
+			Mode:                 schema.ActiveOwnersMode,
+			RecencyThresholdLow:  0.1,
+			RecencyThresholdHigh: 0.3,
+		},
+	}
+
+	output := &schema.AggregateOutput{
+		FileStats: map[string]*schema.FileAggregation{
+			"critical.go": {
+				Commits:       120,
+				RecentCommits: 45,
+				Churn:         3500,
+				RecentChurn:   1600,
+				FirstCommit:   time.Now().Add(-540 * 24 * time.Hour),
+				Contributors: map[string]schema.Metric{
+					"alice": aliceCommits,
+					"bob":   bobCommits,
+					"carol": carolCommits,
+				},
+			},
+		},
+	}
+
+	result := NewFileMetricsBuilder(ctx, cfg.Git, cfg.Scoring, nil, "critical.go", output).
+		FetchAllGitMetrics().
+		FetchFileStats().
+		CalculateDerivedMetrics().
+		FetchRecentInfo().
+		CalculateOwner().
+		CalculateScore().
+		Build()
+
+	assert.Equal(t, schema.ActiveOwnersMode, result.Mode)
+	assert.Equal(t, "composite", result.ModeType)
+	assert.Equal(t, result.AllScores[schema.ActiveOwnersMode], result.ModeScore)
+	assert.Equal(t, result.AllBreakdowns[schema.ActiveOwnersMode], result.ModeBreakdown)
+	assert.NotEmpty(t, result.ModeBreakdown)
+	assert.Contains(t, result.AllBreakdowns, schema.LegacyDebtMode)
+	assert.Greater(t, result.RecencySignal, 0.0)
+	assert.Equal(t, 0.1, result.RecencyThresholdLow)
+	assert.Equal(t, 0.3, result.RecencyThresholdHigh)
 }

--- a/core/check.go
+++ b/core/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/huangsam/hotspot/schema"
@@ -24,16 +25,19 @@ func printCheckResult(result *schema.CheckResult, duration time.Duration) {
 func printCheckHeader(result *schema.CheckResult, duration time.Duration) {
 	fmt.Fprintln(os.Stderr, "Policy Check Results:")
 
+	// Build thresholds string
+	var tStrings []string
+	for _, mode := range result.CheckedModes {
+		tStrings = append(tStrings, fmt.Sprintf("%s=%.1f", mode, result.Thresholds[mode]))
+	}
+
 	// Define labels and values for dynamic padding
 	labels := []string{"Base:", "Target:", "Lookback:", "Thresholds:"}
 	values := []any{
 		result.BaseRef,
 		result.TargetRef,
 		result.Lookback,
-		fmt.Sprintf("hot=%.1f, risk=%.1f, complexity=%.1f",
-			result.Thresholds[schema.HotMode],
-			result.Thresholds[schema.RiskMode],
-			result.Thresholds[schema.ComplexityMode]),
+		strings.Join(tStrings, ", "),
 	}
 
 	// Find the longest label for consistent padding
@@ -100,7 +104,7 @@ func printCheckFailure(result *schema.CheckResult) {
 			return files[i].Score > files[j].Score
 		})
 
-		fmt.Fprintf(os.Stderr, "Mode: %s (%d violations)\n", mode, len(files))
+		_, _ = fmt.Fprintf(os.Stdout, "Mode: %s (%d violations)\n", mode, len(files))
 
 		// Show top 5 violations, with "+X more" if needed
 		maxToShow := 5
@@ -109,13 +113,16 @@ func printCheckFailure(result *schema.CheckResult) {
 			if shown >= maxToShow {
 				remaining := len(files) - shown
 				if remaining > 0 {
-					fmt.Fprintf(os.Stderr, "  ... and %d more\n", remaining)
+					_, _ = fmt.Fprintf(os.Stdout, "  ... and %d more\n", remaining)
 				}
 				break
 			}
-			fmt.Printf("  - %s (score: %.1f > threshold: %.1f)\n", f.Path, f.Score, f.Threshold)
+			_, _ = fmt.Fprintf(os.Stdout, "  - %s (score: %.1f > threshold: %.1f)\n", f.Path, f.Score, f.Threshold)
+			for _, reason := range f.Reasoning {
+				_, _ = fmt.Fprintf(os.Stdout, "      reason: %s\n", reason)
+			}
 			shown++
 		}
-		fmt.Fprintln(os.Stderr)
+		_, _ = fmt.Fprintln(os.Stdout)
 	}
 }

--- a/core/check_test.go
+++ b/core/check_test.go
@@ -1,12 +1,34 @@
 package core
 
 import (
+	"io"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/huangsam/hotspot/schema"
 	"github.com/stretchr/testify/assert"
 )
+
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stdout = w
+	os.Stderr = w
+
+	fn()
+
+	assert.NoError(t, w.Close())
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	out, err := io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
+	return string(out)
+}
 
 func TestPrintCheckResult(t *testing.T) {
 	// Test that printCheckResult doesn't panic with various inputs
@@ -75,4 +97,93 @@ func TestPrintCheckResult(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestPrintCheckResult_ShowsReasoningOnFailures(t *testing.T) {
+	result := schema.CheckResult{
+		Passed: false,
+		FailedFiles: []schema.CheckFailedFile{
+			{
+				Path:      "main.go",
+				Mode:      schema.HotMode,
+				Score:     75.5,
+				Threshold: 50.0,
+				Reasoning: []string{"High Churn", "Concentrated ownership"},
+			},
+		},
+		TotalFiles:   5,
+		CheckedModes: []schema.ScoringMode{schema.HotMode, schema.RiskMode},
+		BaseRef:      "main",
+		TargetRef:    "HEAD",
+		Thresholds: map[schema.ScoringMode]float64{
+			schema.HotMode:  50.0,
+			schema.RiskMode: 50.0,
+		},
+		MaxScores: map[schema.ScoringMode]float64{
+			schema.HotMode: 75.5,
+		},
+		Lookback: 180 * 24 * time.Hour,
+	}
+
+	output := captureOutput(t, func() {
+		printCheckResult(&result, time.Second)
+	})
+
+	assert.Contains(t, output, "reason: High Churn")
+	assert.Contains(t, output, "reason: Concentrated ownership")
+}
+
+func TestPrintCheckResult_FailureOutputGolden(t *testing.T) {
+	result := schema.CheckResult{
+		Passed: false,
+		FailedFiles: []schema.CheckFailedFile{
+			{
+				Path:      "cmd/a.go",
+				Mode:      schema.HotMode,
+				Score:     81.0,
+				Threshold: 50.0,
+				Reasoning: []string{"High Churn", "Active Frontier"},
+			},
+			{
+				Path:      "cmd/b.go",
+				Mode:      schema.HotMode,
+				Score:     70.0,
+				Threshold: 50.0,
+				Reasoning: []string{"Development Bottleneck"},
+			},
+		},
+		TotalFiles:   3,
+		CheckedModes: []schema.ScoringMode{schema.HotMode, schema.RiskMode},
+		BaseRef:      "main",
+		TargetRef:    "HEAD",
+		Thresholds: map[schema.ScoringMode]float64{
+			schema.HotMode:  50.0,
+			schema.RiskMode: 45.0,
+		},
+		MaxScores: map[schema.ScoringMode]float64{
+			schema.HotMode: 81.0,
+		},
+		Lookback: 180 * 24 * time.Hour,
+	}
+
+	output := captureOutput(t, func() {
+		printCheckResult(&result, 2*time.Second)
+	})
+
+	expected := "" +
+		"Policy Check Results:\n" +
+		"  Base:        main\n" +
+		"  Target:      HEAD\n" +
+		"  Lookback:    4320h0m0s\n" +
+		"  Thresholds:  hot=50.0, risk=45.0\n\n" +
+		"Checked 3 files in 2s\n\n" +
+		"FAIL: Policy check failed: 2 violation(s) found across 3 files\n\n" +
+		"Mode: hot (2 violations)\n" +
+		"  - cmd/a.go (score: 81.0 > threshold: 50.0)\n" +
+		"      reason: High Churn\n" +
+		"      reason: Active Frontier\n" +
+		"  - cmd/b.go (score: 70.0 > threshold: 50.0)\n" +
+		"      reason: Development Bottleneck\n\n"
+
+	assert.Equal(t, expected, output)
 }

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,6 +1,6 @@
 # CI/CD Policy Enforcement
 
-The `check` command allows you to enforce risk thresholds in CI/CD pipelines, failing builds when files exceed acceptable risk levels. Default thresholds: 50.0 for all scoring modes (hot, risk, complexity, roi).
+The `check` command allows you to enforce risk thresholds in CI/CD pipelines, failing builds when files exceed acceptable risk levels. Default thresholds: 50.0 for all scoring modes (hot, risk, complexity, roi, active_owners, refactor_now, legacy_debt).
 
 ## Examples
 
@@ -8,7 +8,7 @@ The `check` command allows you to enforce risk thresholds in CI/CD pipelines, fa
 `hotspot check --base-ref v1.17.0 --target-ref v1.18.0`
 
 **2. Custom thresholds via CLI:**
-`hotspot check --base-ref v1.17.0 --target-ref v1.18.0 --thresholds-override "hot:75,risk:60,complexity:80"`
+`hotspot check --base-ref v1.17.0 --target-ref v1.18.0 --thresholds-override "hot:75,risk:60,complexity:80,active_owners:70"`
 
 ## Reference
 
@@ -17,6 +17,6 @@ The `check` command allows you to enforce risk thresholds in CI/CD pipelines, fa
 | `--base-ref` | The BEFORE Git reference (e.g., `main`, `v1.0.0`, a commit hash). |
 | `--target-ref` | The AFTER Git reference (defaults to `HEAD`). |
 | `--lookback` | Time window (e.g. `6 months`) used for base and target. |
-| `--thresholds-override` | Custom risk thresholds per scoring mode (format: `hot:50,risk:50,complexity:50,roi:50`). |
+| `--thresholds-override` | Custom risk thresholds per scoring mode (format: `hot:50,risk:50,complexity:50,roi:50,active_owners:50,refactor_now:50,legacy_debt:50`). |
 
 The [example CI config](../examples/reference/hotspot.ci.yml) shows how custom thresholds can be configured for each scoring mode and is useful for maintaining code quality standards specific to your team.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -599,7 +599,7 @@ func validateScoringInputs(cfg *Config, input *RawInput) error {
 	if input.Mode != "" {
 		cfg.Scoring.Mode = schema.ScoringMode(strings.ToLower(input.Mode))
 		if _, ok := schema.ValidScoringModes[cfg.Scoring.Mode]; !ok {
-			return fmt.Errorf("invalid mode '%s'. Must be one of: hot (activity), risk (knowledge distribution), complexity (technical debt)", input.Mode)
+			return fmt.Errorf("invalid mode '%s'. Base modes: hot (activity), risk (knowledge distribution), complexity (technical debt), roi (refactoring priority). Composite modes: active_owners, refactor_now, legacy_debt", input.Mode)
 		}
 	} else if cfg.Scoring.Mode == "" {
 		cfg.Scoring.Mode = schema.HotMode
@@ -989,6 +989,9 @@ func processRiskThresholds(cfg *Config, input *RawInput) error {
 	thresholds[schema.RiskMode] = 50.0
 	thresholds[schema.ComplexityMode] = 50.0
 	thresholds[schema.ROIMode] = 50.0
+	thresholds[schema.ActiveOwnersMode] = 50.0
+	thresholds[schema.RefactorNowMode] = 50.0
+	thresholds[schema.LegacyDebtMode] = 50.0
 
 	// Override with config file values if provided
 	if input.Thresholds.Hot != nil {
@@ -1002,6 +1005,15 @@ func processRiskThresholds(cfg *Config, input *RawInput) error {
 	}
 	if input.Thresholds.ROI != nil {
 		thresholds[schema.ROIMode] = *input.Thresholds.ROI
+	}
+	if input.Thresholds.ActiveOwners != nil {
+		thresholds[schema.ActiveOwnersMode] = *input.Thresholds.ActiveOwners
+	}
+	if input.Thresholds.RefactorNow != nil {
+		thresholds[schema.RefactorNowMode] = *input.Thresholds.RefactorNow
+	}
+	if input.Thresholds.LegacyDebt != nil {
+		thresholds[schema.LegacyDebtMode] = *input.Thresholds.LegacyDebt
 	}
 
 	// Override with command-line flag if provided (takes precedence)
@@ -1113,8 +1125,14 @@ func parseRiskThresholdsString(s string) (map[schema.ScoringMode]float64, error)
 			mode = schema.ComplexityMode
 		case "roi":
 			mode = schema.ROIMode
+		case "active_owners":
+			mode = schema.ActiveOwnersMode
+		case "refactor_now":
+			mode = schema.RefactorNowMode
+		case "legacy_debt":
+			mode = schema.LegacyDebtMode
 		default:
-			return nil, fmt.Errorf("invalid mode '%s', must be hot, risk, complexity or roi", modeStr)
+			return nil, fmt.Errorf("invalid mode '%s', must be %s", modeStr, formatThresholdModeList())
 		}
 
 		value, err := strconv.ParseFloat(valueStr, 64)
@@ -1126,6 +1144,18 @@ func parseRiskThresholdsString(s string) (map[schema.ScoringMode]float64, error)
 	}
 
 	return thresholds, nil
+}
+
+func formatThresholdModeList() string {
+	modeNames := make([]string, 0, len(schema.AllScoringModes))
+	for _, mode := range schema.AllScoringModes {
+		modeNames = append(modeNames, string(mode))
+	}
+	if len(modeNames) == 1 {
+		return modeNames[0]
+	}
+
+	return strings.Join(modeNames[:len(modeNames)-1], ", ") + " or " + modeNames[len(modeNames)-1]
 }
 
 // ProfileConfig holds profiling settings.
@@ -1157,8 +1187,11 @@ type ModeWeightsRaw struct {
 
 // ThresholdsRawInput holds the raw risk thresholds from the config file.
 type ThresholdsRawInput struct {
-	Hot        *float64 `mapstructure:"hot"`
-	Risk       *float64 `mapstructure:"risk"`
-	Complexity *float64 `mapstructure:"complexity"`
-	ROI        *float64 `mapstructure:"roi"`
+	Hot          *float64 `mapstructure:"hot"`
+	Risk         *float64 `mapstructure:"risk"`
+	Complexity   *float64 `mapstructure:"complexity"`
+	ROI          *float64 `mapstructure:"roi"`
+	ActiveOwners *float64 `mapstructure:"active_owners"`
+	RefactorNow  *float64 `mapstructure:"refactor_now"`
+	LegacyDebt   *float64 `mapstructure:"legacy_debt"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -905,6 +905,41 @@ func TestConfigClone(t *testing.T) {
 	assert.NotEqual(t, original.Scoring.CustomWeights[schema.HotMode][schema.BreakdownCommits], clone.Scoring.CustomWeights[schema.HotMode][schema.BreakdownCommits])
 }
 
+func TestParseRiskThresholdsStringSupportsCompositeModes(t *testing.T) {
+	parsed, err := parseRiskThresholdsString("hot:10,risk:20,complexity:30,roi:40,active_owners:50,refactor_now:60,legacy_debt:70")
+	require.NoError(t, err)
+	assert.Equal(t, 10.0, parsed[schema.HotMode])
+	assert.Equal(t, 20.0, parsed[schema.RiskMode])
+	assert.Equal(t, 30.0, parsed[schema.ComplexityMode])
+	assert.Equal(t, 40.0, parsed[schema.ROIMode])
+	assert.Equal(t, 50.0, parsed[schema.ActiveOwnersMode])
+	assert.Equal(t, 60.0, parsed[schema.RefactorNowMode])
+	assert.Equal(t, 70.0, parsed[schema.LegacyDebtMode])
+
+	_, err = parseRiskThresholdsString("unknown:10")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "active_owners")
+	assert.Contains(t, err.Error(), "refactor_now")
+	assert.Contains(t, err.Error(), "legacy_debt")
+}
+
+func TestProcessRiskThresholdsSupportsCompositeConfigKeys(t *testing.T) {
+	cfg := &Config{}
+	input := &RawInput{
+		Thresholds: ThresholdsRawInput{
+			ActiveOwners: &[]float64{61}[0],
+			RefactorNow:  &[]float64{62}[0],
+			LegacyDebt:   &[]float64{63}[0],
+		},
+	}
+
+	err := processRiskThresholds(cfg, input)
+	require.NoError(t, err)
+	assert.Equal(t, 61.0, cfg.Scoring.RiskThresholds[schema.ActiveOwnersMode])
+	assert.Equal(t, 62.0, cfg.Scoring.RiskThresholds[schema.RefactorNowMode])
+	assert.Equal(t, 63.0, cfg.Scoring.RiskThresholds[schema.LegacyDebtMode])
+}
+
 func TestConfigCloneWithTimeWindow(t *testing.T) {
 	original := &Config{
 		Output: OutputConfig{

--- a/internal/mcp/mcp_handlers.go
+++ b/internal/mcp/mcp_handlers.go
@@ -458,8 +458,8 @@ func (h *toolHandler) handleGetPrompt(_ context.Context, request mcp.GetPromptRe
 					Type: "text",
 					Text: `Help me prioritize refactoring targets by following this workflow:
 1. Run 'get_repo_shape' to ensure we are using the correct preset for this codebase.
-2. Use 'get_files_hotspots' with the recommended preset and mode='roi' to identify files with the highest return on refactoring investment.
-3. For the top 3 files identified, use 'get_timeseries' to see if their risk profile is improving or worsening over the last 6 months.
+2. Use 'get_files_hotspots' with the recommended preset and mode='refactor_now' to identify complex, high-churn legacy files that offer the highest return on refactoring investment.
+3. For the top 3 files identified, use 'get_timeseries' with mode='refactor_now' to see if their risk profile is improving or worsening over the last 6 months.
 4. Provide a prioritized list of refactoring candidates with justifications based on churn, complexity, and historical trends.`,
 				},
 			},
@@ -472,10 +472,9 @@ func (h *toolHandler) handleGetPrompt(_ context.Context, request mcp.GetPromptRe
 					Type: "text",
 					Text: `Assess whether this repository is ready for a release cut by following this workflow:
 1. Run 'get_repo_shape' to identify the preset and recommended scoring mode.
-2. Use 'compare_hotspots' with base_ref set to the most recent tag and target_ref='HEAD', mode='hot' to identify files that have spiked in activity since the last release.
-3. Re-run 'compare_hotspots' with the same refs but mode='risk' to surface any newly-introduced knowledge silos or ownership concentration.
-4. If any files appear in BOTH the hot and risk results, flag them as release blockers — they are simultaneously volatile and fragile.
-5. Provide a clear go/no-go recommendation with a short list of specific files and the reason each one is a concern, or confirm the release looks clean.`,
+2. Use 'compare_file_hotspots' with base_ref set to the most recent tag and target_ref='HEAD', mode='active_owners' to instantly identify files that have spiked in activity and have concentrated ownership since the last release.
+3. If any files appear with a high score, flag them as release blockers — they are simultaneously volatile and fragile.
+4. Provide a clear go/no-go recommendation with a short list of specific files and their reasoning labels, or confirm the release looks clean.`,
 				},
 			},
 		}

--- a/internal/mcp/mcp_server.go
+++ b/internal/mcp/mcp_server.go
@@ -35,7 +35,7 @@ func NewMCPServer(baseCfg *config.Config, mgr iocache.CacheManager, client git.C
 	// Common parameter descriptions
 	urnDesc := "Universal Resource Name (e.g., 'git:github.com/org/repo' or 'local:hash'). If provided, repo_path is optional and utilizes cached/historical analysis results."
 	repoPathDesc := "Path to the Git repository (defaults to current directory if not specified)."
-	modeDesc := "Scoring mode: 'hot' (activity hotspots), 'risk' (knowledge silos/bus factor), 'complexity' (technical debt candidates), or 'roi' (refactoring priority)."
+	modeDesc := "Scoring mode: 'hot' (activity hotspots), 'risk' (knowledge silos/bus factor), 'complexity' (technical debt candidates), 'roi' (refactoring priority), or composite modes: 'active_owners' (volatile + siloed), 'refactor_now' (high ROI targets), 'legacy_debt' (fragile + under-maintained)."
 	startDesc := "Start date for the analysis window (ISO8601 e.g. '2024-01-01T00:00:00Z', or relative e.g. '30d ago', '6 months ago')."
 	endDesc := "End date for the analysis window (ISO8601 or relative). Defaults to now."
 
@@ -62,7 +62,7 @@ func NewMCPServer(baseCfg *config.Config, mgr iocache.CacheManager, client git.C
 		mcp.WithString("preset", mcp.Description("Apply a named configuration preset (small, large, infra). It is recommended to run 'get_repo_shape' first to identify the correct preset for this repository."), mcp.Enum("small", "large", "infra")),
 		mcp.WithString("urn", mcp.Description(urnDesc)),
 		mcp.WithString("repo_path", mcp.Description(repoPathDesc)),
-		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi"), mcp.DefaultString("hot")),
+		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi", "active_owners", "refactor_now", "legacy_debt"), mcp.DefaultString("hot")),
 		mcp.WithNumber("limit", mcp.Description("Limit the number of results returned."), mcp.DefaultNumber(10)),
 		mcp.WithString("start", mcp.Description(startDesc)),
 		mcp.WithString("end", mcp.Description(endDesc)),
@@ -81,7 +81,7 @@ func NewMCPServer(baseCfg *config.Config, mgr iocache.CacheManager, client git.C
 		mcp.WithString("preset", mcp.Description("Apply a named configuration preset (small, large, infra). It is recommended to run 'get_repo_shape' first to identify the correct preset for this repository."), mcp.Enum("small", "large", "infra")),
 		mcp.WithString("urn", mcp.Description(urnDesc)),
 		mcp.WithString("repo_path", mcp.Description(repoPathDesc)),
-		mcp.WithString("mode", mcp.Description("Scoring mode: 'hot' (activity/volatility), 'risk' (knowledge silos/bus factor), 'complexity' (legacy technical debt), or 'roi' (refactoring priority)."), mcp.Enum("hot", "risk", "complexity", "roi"), mcp.DefaultString("hot")),
+		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi", "active_owners", "refactor_now", "legacy_debt"), mcp.DefaultString("hot")),
 		mcp.WithString("start", mcp.Description(startDesc)),
 		mcp.WithString("end", mcp.Description(endDesc)),
 		mcp.WithString("exclude", mcp.Description("Comma-separated list of glob patterns to exclude (e.g. '**/vendor/, **/*.pb.go')."), mcp.DefaultString(schema.DefaultExclude)),
@@ -100,7 +100,7 @@ func NewMCPServer(baseCfg *config.Config, mgr iocache.CacheManager, client git.C
 		mcp.WithString("preset", mcp.Description("Apply a named configuration preset (small, large, infra). It is recommended to run 'get_repo_shape' first to identify the correct preset for this repository."), mcp.Enum("small", "large", "infra")),
 		mcp.WithString("urn", mcp.Description(urnDesc)),
 		mcp.WithString("repo_path", mcp.Description(repoPathDesc)),
-		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi"), mcp.DefaultString("hot")),
+		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi", "active_owners", "refactor_now", "legacy_debt"), mcp.DefaultString("hot")),
 		mcp.WithNumber("limit", mcp.Description("Limit the number of results."), mcp.DefaultNumber(10)),
 		mcp.WithString("start", mcp.Description(startDesc)),
 		mcp.WithString("end", mcp.Description(endDesc)),
@@ -122,7 +122,7 @@ func NewMCPServer(baseCfg *config.Config, mgr iocache.CacheManager, client git.C
 		mcp.WithString("urn", mcp.Description(urnDesc)),
 		mcp.WithString("lookback", mcp.Description("Time window for analysis (e.g., '6 months', '30d').")),
 		mcp.WithString("repo_path", mcp.Description(repoPathDesc)),
-		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi"), mcp.DefaultString("hot")),
+		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi", "active_owners", "refactor_now", "legacy_debt"), mcp.DefaultString("hot")),
 		mcp.WithString("start", mcp.Description(startDesc)),
 		mcp.WithString("end", mcp.Description(endDesc)),
 		mcp.WithString("exclude", mcp.Description("Comma-separated list of glob patterns to exclude (e.g. '**/vendor/, **/*.pb.go')."), mcp.DefaultString(schema.DefaultExclude)),
@@ -143,7 +143,7 @@ func NewMCPServer(baseCfg *config.Config, mgr iocache.CacheManager, client git.C
 		mcp.WithString("urn", mcp.Description(urnDesc)),
 		mcp.WithString("lookback", mcp.Description("Time window for analysis (e.g., '6 months', '30d').")),
 		mcp.WithString("repo_path", mcp.Description(repoPathDesc)),
-		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi"), mcp.DefaultString("hot")),
+		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi", "active_owners", "refactor_now", "legacy_debt"), mcp.DefaultString("hot")),
 		mcp.WithString("start", mcp.Description(startDesc)),
 		mcp.WithString("end", mcp.Description(endDesc)),
 		mcp.WithString("exclude", mcp.Description("Comma-separated list of glob patterns to exclude (e.g. '**/vendor/, **/*.pb.go')."), mcp.DefaultString(schema.DefaultExclude)),
@@ -164,7 +164,7 @@ func NewMCPServer(baseCfg *config.Config, mgr iocache.CacheManager, client git.C
 		mcp.WithString("preset", mcp.Description("Apply a named configuration preset (small, large, infra). It is recommended to run 'get_repo_shape' first to identify the correct preset for this repository."), mcp.Enum("small", "large", "infra")),
 		mcp.WithString("urn", mcp.Description(urnDesc)),
 		mcp.WithString("repo_path", mcp.Description(repoPathDesc)),
-		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi"), mcp.DefaultString("hot")),
+		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi", "active_owners", "refactor_now", "legacy_debt"), mcp.DefaultString("hot")),
 		mcp.WithString("start", mcp.Description("Start date for the entire timeseries window (anchors the first point).")),
 		mcp.WithString("end", mcp.Description("End date for the entire timeseries window.")),
 		mcp.WithString("exclude", mcp.Description("Comma-separated list of glob patterns to exclude (e.g. '**/vendor/, **/*.pb.go')."), mcp.DefaultString(schema.DefaultExclude)),
@@ -182,7 +182,7 @@ func NewMCPServer(baseCfg *config.Config, mgr iocache.CacheManager, client git.C
 		mcp.WithString("preset", mcp.Description("Apply a named configuration preset (small, large, infra). It is recommended to run 'get_repo_shape' first to identify the correct preset for this repository."), mcp.Enum("small", "large", "infra")),
 		mcp.WithString("urn", mcp.Description(urnDesc)),
 		mcp.WithString("repo_path", mcp.Description(repoPathDesc)),
-		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi"), mcp.DefaultString("hot")),
+		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi", "active_owners", "refactor_now", "legacy_debt"), mcp.DefaultString("hot")),
 		mcp.WithNumber("transitions", mcp.Description("Number of successive tag transitions to analyze (e.g. 3 = last 4 tags). Defaults to 3."), mcp.DefaultNumber(3)),
 		mcp.WithString("exclude", mcp.Description("Comma-separated list of glob patterns to exclude (e.g. '**/vendor/, **/*.pb.go')."), mcp.DefaultString(schema.DefaultExclude)),
 		mcp.WithString("filter", mcp.Description("Path prefix to filter analysis to a specific directory (e.g. 'src/main/').")),
@@ -218,6 +218,7 @@ func NewMCPServer(baseCfg *config.Config, mgr iocache.CacheManager, client git.C
 		mcp.WithString("target_ref", mcp.Description("The target reference for comparison."), mcp.Required()),
 		mcp.WithString("urn", mcp.Description(urnDesc)),
 		mcp.WithString("repo_path", mcp.Description(repoPathDesc)),
+		mcp.WithString("mode", mcp.Description(modeDesc), mcp.Enum("hot", "risk", "complexity", "roi", "active_owners", "refactor_now", "legacy_debt"), mcp.DefaultString("hot")),
 		mcp.WithString("lookback", mcp.Description("Time window for analysis.")),
 		mcp.WithString("exclude", mcp.Description("Comma-separated list of glob patterns to exclude."), mcp.DefaultString(schema.DefaultExclude)),
 	), withRecovery(h.handleRunCheck))

--- a/schema/config_loader.go
+++ b/schema/config_loader.go
@@ -12,6 +12,9 @@ var scoringConfigRaw []byte
 //go:embed data/presets.yaml
 var presetsRaw []byte
 
+//go:embed data/composites.yaml
+var compositesRaw []byte
+
 type modeConfig struct {
 	Name       string             `yaml:"name"`
 	Purpose    string             `yaml:"purpose"`
@@ -24,9 +27,14 @@ type scoringConfig struct {
 	Modes map[string]modeConfig `yaml:"modes"`
 }
 
+type compositesConfig struct {
+	Composites map[ScoringMode]*CompositeConfig `yaml:"composites"`
+}
+
 var (
 	sCfg scoringConfig
 	pCfg map[string]Preset
+	cCfg compositesConfig
 )
 
 func init() {
@@ -35,6 +43,9 @@ func init() {
 	}
 	if err := yaml.Unmarshal(presetsRaw, &pCfg); err != nil {
 		panic("failed to unmarshal presets.yaml: " + err.Error())
+	}
+	if err := yaml.Unmarshal(compositesRaw, &cCfg); err != nil {
+		panic("failed to unmarshal composites.yaml: " + err.Error())
 	}
 }
 
@@ -79,4 +90,14 @@ func AllPresets() []Preset {
 		GetPreset(PresetLarge),
 		GetPreset(PresetInfra),
 	}
+}
+
+// GetCompositeConfig returns the CompositeConfig for a given composite mode.
+// Returns nil if the mode is not a composite.
+func GetCompositeConfig(mode ScoringMode) *CompositeConfig {
+	cfg, ok := cCfg.Composites[mode]
+	if !ok {
+		return nil
+	}
+	return cfg
 }

--- a/schema/constants.go
+++ b/schema/constants.go
@@ -58,6 +58,10 @@ const (
 	RiskMode       ScoringMode = "risk"
 	ComplexityMode ScoringMode = "complexity"
 	ROIMode        ScoringMode = "roi"
+	// Composite modes (v1.22.0+).
+	ActiveOwnersMode ScoringMode = "active_owners"
+	RefactorNowMode  ScoringMode = "refactor_now"
+	LegacyDebtMode   ScoringMode = "legacy_debt"
 )
 
 // Scoring label constants for criticality levels.
@@ -76,8 +80,11 @@ const (
 	NoneBackend       DatabaseBackend = "none"
 )
 
-// AllScoringModes returns a list of all supported scoring modes.
-var AllScoringModes = []ScoringMode{HotMode, RiskMode, ComplexityMode, ROIMode}
+// BaseScoringModes returns the four base scoring modes.
+var BaseScoringModes = []ScoringMode{HotMode, RiskMode, ComplexityMode, ROIMode}
+
+// AllScoringModes returns all supported scoring modes (base + composite).
+var AllScoringModes = []ScoringMode{HotMode, RiskMode, ComplexityMode, ROIMode, ActiveOwnersMode, RefactorNowMode, LegacyDebtMode}
 
 // ValidOutputModes lists all valid output modes.
 var ValidOutputModes = map[OutputMode]struct{}{
@@ -93,10 +100,13 @@ var ValidOutputModes = map[OutputMode]struct{}{
 
 // ValidScoringModes lists all valid scoring modes.
 var ValidScoringModes = map[ScoringMode]struct{}{
-	HotMode:        {},
-	RiskMode:       {},
-	ComplexityMode: {},
-	ROIMode:        {},
+	HotMode:          {},
+	RiskMode:         {},
+	ComplexityMode:   {},
+	ROIMode:          {},
+	ActiveOwnersMode: {},
+	RefactorNowMode:  {},
+	LegacyDebtMode:   {},
 }
 
 // ValidDatabaseBackends lists all valid database backends.

--- a/schema/data/composites.yaml
+++ b/schema/data/composites.yaml
@@ -1,0 +1,37 @@
+# Composite Scoring Modes for Hotspot v1.22.0+
+# Composites blend two base scoring modes to surface different problem types.
+# Reasoning is generated compositionally by joining reasoning from each base mode.
+
+composites:
+  # Active Owners: High recent activity + concentrated ownership = immediate risk
+  active_owners:
+    display_name: "Active Owners"
+    description: "Files with high recent activity AND concentrated ownership—highest urgency for knowledge transfer."
+    base_modes:
+      - "hot"      # 50% weight: recent volatility signals
+      - "risk"     # 50% weight: knowledge silo signals
+    blend_weights:
+      hot: 0.5
+      risk: 0.5
+
+  # Refactoring Goldmine: High churn on complex legacy = highest ROI per hour
+  refactor_now:
+    display_name: "Refactoring Goldmine"
+    description: "High churn on complex legacy code—prioritizes files with the highest technical return per refactoring effort."
+    base_modes:
+      - "complexity"  # 60% weight: maintenance burden (effort)
+      - "roi"         # 40% weight: current impact (benefit)
+    blend_weights:
+      complexity: 0.6
+      roi: 0.4
+
+  # Sleeping Dragon: Fragile, under-maintained, critical systems
+  legacy_debt:
+    display_name: "Sleeping Dragon"
+    description: "Fragile, under-maintained systems with concentrated ownership—high blast radius if touched."
+    base_modes:
+      - "complexity"  # 70% weight: fragility (maintenance burden)
+      - "risk"        # 30% weight: bus factor (knowledge risk)
+    blend_weights:
+      complexity: 0.7
+      risk: 0.3

--- a/schema/helpers.go
+++ b/schema/helpers.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -316,4 +317,14 @@ func IsPathInFilter(path, filter string) bool {
 	}
 
 	return strings.HasPrefix(path, filter)
+}
+
+// IsCompositeMode returns true if the given mode is a composite scoring mode.
+func IsCompositeMode(mode ScoringMode) bool {
+	return slices.Contains(AllScoringModes, mode) && !IsBaseMode(mode)
+}
+
+// IsBaseMode returns true if the given mode is one of the four base scoring modes.
+func IsBaseMode(mode ScoringMode) bool {
+	return slices.Contains(BaseScoringModes, mode)
 }

--- a/schema/helpers_test.go
+++ b/schema/helpers_test.go
@@ -123,6 +123,22 @@ func TestGetDefaultWeights(t *testing.T) {
 	}
 }
 
+func TestModeTypeHelpersUseModeLists(t *testing.T) {
+	for _, mode := range BaseScoringModes {
+		assert.True(t, IsBaseMode(mode))
+		assert.False(t, IsCompositeMode(mode))
+	}
+
+	for _, mode := range AllScoringModes {
+		if !IsBaseMode(mode) {
+			assert.True(t, IsCompositeMode(mode))
+		}
+	}
+
+	assert.False(t, IsBaseMode(ScoringMode("unknown_mode")))
+	assert.False(t, IsCompositeMode(ScoringMode("unknown_mode")))
+}
+
 func TestFileResultGetters(t *testing.T) {
 	file := FileResult{
 		Path:      "src/main.go",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -30,11 +30,13 @@ type FileResult struct {
 	RecencyThresholdHigh float64   `json:"recency_threshold_high"`
 
 	Mode          ScoringMode                              `json:"mode"`                 // Scoring mode used (hot, risk, complexity, roi)
+	ModeType      string                                   `json:"mode_type"`            // Type of mode: 'base' or 'composite'
 	ModeScore     float64                                  `json:"score"`                // Computed score for the current mode (0-100)
 	Reasoning     []string                                 `json:"reasoning,omitempty"`  // Human-and-AI-readable justifications for the score
 	ModeBreakdown map[BreakdownKey]float64                 `json:"breakdown"`            // Normalized contribution of each metric to the score
 	AllScores     map[ScoringMode]float64                  `json:"scores"`               // All computed scores by mode
 	AllBreakdowns map[ScoringMode]map[BreakdownKey]float64 `json:"breakdowns,omitempty"` // Score breakdowns for all modes
+	AllReasoning  map[ScoringMode][]string                 `json:"reasonings,omitempty"` // Reasoning for all computed modes
 }
 
 // GetPath returns the file path.
@@ -73,6 +75,7 @@ type FolderResult struct {
 	DecayedCommits     Metric   `json:"decayed_commits"`     // Time-weighted commits across all contained files
 	DecayedChurn       Metric   `json:"decayed_churn"`       // Time-weighted churn across all contained files
 	Score              float64  `json:"score"`               // Computed importance score for the folder
+	ModeType           string   `json:"mode_type"`           // Type of mode: 'base' or 'composite'
 	Gini               float64  `json:"gini"`                // Gini coefficient of commit distribution in the folder
 	UniqueContributors Metric   `json:"unique_contributors"` // Number of unique contributors in the folder
 	Owners             []string `json:"owners"`              // Top 2 owners by commit count
@@ -108,4 +111,12 @@ func (f FolderResult) GetOwners() []string {
 		return []string{}
 	}
 	return f.Owners
+}
+
+// CompositeConfig represents the definition of a composite scoring mode.
+type CompositeConfig struct {
+	DisplayName  string                  `yaml:"display_name"`
+	Description  string                  `yaml:"description"`
+	BaseModes    []ScoringMode           `yaml:"base_modes"`
+	BlendWeights map[ScoringMode]float64 `yaml:"blend_weights"`
 }

--- a/schema/schema_check.go
+++ b/schema/schema_check.go
@@ -29,4 +29,5 @@ type CheckFailedFile struct {
 	Mode      ScoringMode
 	Score     float64
 	Threshold float64
+	Reasoning []string
 }

--- a/schema/schema_metrics.go
+++ b/schema/schema_metrics.go
@@ -33,7 +33,7 @@ type MetricsModeWithData struct {
 // BuildMetricsRenderModel constructs the complete render model with all processed data.
 func BuildMetricsRenderModel(activeWeights map[ScoringMode]map[BreakdownKey]float64) *MetricsRenderModel {
 	var modes []MetricsMode
-	for _, mode := range AllScoringModes {
+	for _, mode := range BaseScoringModes {
 		purpose, factors, factorKeys := GetScoringModeMetadata(mode)
 		modes = append(modes, MetricsMode{
 			Name:       string(mode),

--- a/schema/schema_metrics_test.go
+++ b/schema/schema_metrics_test.go
@@ -1,0 +1,25 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildMetricsRenderModel_UsesBaseModesOnly(t *testing.T) {
+	model := BuildMetricsRenderModel(nil)
+	assert.Len(t, model.Modes, len(BaseScoringModes))
+
+	var names []string
+	for _, mode := range model.Modes {
+		names = append(names, mode.Name)
+	}
+
+	assert.Contains(t, names, string(HotMode))
+	assert.Contains(t, names, string(RiskMode))
+	assert.Contains(t, names, string(ComplexityMode))
+	assert.Contains(t, names, string(ROIMode))
+	assert.NotContains(t, names, string(ActiveOwnersMode))
+	assert.NotContains(t, names, string(RefactorNowMode))
+	assert.NotContains(t, names, string(LegacyDebtMode))
+}


### PR DESCRIPTION
This PR introduces high-precision **Composite Scoring Modes** (`active_owners`, `refactor_now`, and `legacy_debt`) to the Hotspot engine, enabling targeted risk identification by intelligently blending base scoring signals (e.g., volatile churn + concentrated ownership). Beyond the algorithmic blending, this work hardens the core analysis pipeline to ensure these composite signals are fully integrated into CI/CD gating; the `check` command now enforces a default 50.0 risk threshold across all seven modes and provides enriched reasoning labels to justify policy violations. Additionally, the MCP layer has been optimized with refined prompts and tool definitions, allowing AI agents to instantly surface complex architectural risks—such as "volatile knowledge silos"—using single-pass composite queries rather than manual multi-mode correlation.